### PR TITLE
app.go and module manager clean up

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -2,11 +2,11 @@ package ante
 
 import (
 	paramkeeper "cosmossdk.io/x/params/keeper"
+	"cosmossdk.io/x/tx/signing"
 	blobante "github.com/celestiaorg/celestia-app/v3/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v3/x/blob/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	ibcante "github.com/cosmos/ibc-go/v9/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v9/modules/core/keeper"
@@ -17,7 +17,7 @@ func NewAnteHandler(
 	bankKeeper authtypes.BankKeeper,
 	blobKeeper blob.Keeper,
 	feegrantKeeper ante.FeegrantKeeper,
-	signModeHandler signing.SignModeHandler,
+	signModeHandler *signing.HandlerMap,
 	sigGasConsumer ante.SignatureVerificationGasConsumer,
 	channelKeeper *ibckeeper.Keeper,
 	paramKeeper paramkeeper.Keeper,

--- a/app/app.go
+++ b/app/app.go
@@ -1,20 +1,14 @@
 package app
 
 import (
+	"context"
+	"cosmossdk.io/math"
 	"fmt"
 	"io"
 	"slices"
 	"time"
 
-	"cosmossdk.io/x/params"
-	paramproposal "cosmossdk.io/x/params/types/proposal"
-
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
-	"cosmossdk.io/x/accounts/defaults/multisig"
-	"cosmossdk.io/x/consensus"
-
-	"github.com/cosmos/cosmos-sdk/runtime"
-
 	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -22,9 +16,11 @@ import (
 	"cosmossdk.io/x/accounts/accountstd"
 	baseaccount "cosmossdk.io/x/accounts/defaults/base"
 	lockup "cosmossdk.io/x/accounts/defaults/lockup"
+	"cosmossdk.io/x/accounts/defaults/multisig"
 	authzkeeper "cosmossdk.io/x/authz/keeper"
 	bankkeeper "cosmossdk.io/x/bank/keeper"
 	banktypes "cosmossdk.io/x/bank/types"
+	"cosmossdk.io/x/consensus"
 	consensuskeeper "cosmossdk.io/x/consensus/keeper"
 	consensustypes "cosmossdk.io/x/consensus/types"
 	distrkeeper "cosmossdk.io/x/distribution/keeper"
@@ -35,10 +31,11 @@ import (
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	govkeeper "cosmossdk.io/x/gov/keeper"
 	govtypes "cosmossdk.io/x/gov/types"
-	govv1beta2 "cosmossdk.io/x/gov/types/v1"
 	govv1beta1 "cosmossdk.io/x/gov/types/v1beta1"
+	"cosmossdk.io/x/params"
 	paramskeeper "cosmossdk.io/x/params/keeper"
 	paramstypes "cosmossdk.io/x/params/types"
+	paramproposal "cosmossdk.io/x/params/types/proposal"
 	poolkeeper "cosmossdk.io/x/protocolpool/keeper"
 	pooltypes "cosmossdk.io/x/protocolpool/types"
 	slashingkeeper "cosmossdk.io/x/slashing/keeper"
@@ -57,7 +54,6 @@ import (
 	appv1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	appv2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
 	appv3 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v3"
-	"github.com/celestiaorg/celestia-app/v3/pkg/proof"
 	blobkeeper "github.com/celestiaorg/celestia-app/v3/x/blob/keeper"
 	blobtypes "github.com/celestiaorg/celestia-app/v3/x/blob/types"
 	blobstreamkeeper "github.com/celestiaorg/celestia-app/v3/x/blobstream/keeper"
@@ -66,11 +62,17 @@ import (
 	mintkeeper "github.com/celestiaorg/celestia-app/v3/x/mint/keeper"
 	minttypes "github.com/celestiaorg/celestia-app/v3/x/mint/types"
 	"github.com/celestiaorg/celestia-app/v3/x/signal"
+	signaltypes "github.com/celestiaorg/celestia-app/v3/x/signal/types"
+	cmtcrypto "github.com/cometbft/cometbft/crypto"
+	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -79,6 +81,8 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	icacontrollerkeeper "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/controller/keeper"
+	icacontrollertypes "github.com/cosmos/ibc-go/v9/modules/apps/27-interchain-accounts/controller/types"
 	ibcfeekeeper "github.com/cosmos/ibc-go/v9/modules/apps/29-fee/keeper"
 	ibcfeetypes "github.com/cosmos/ibc-go/v9/modules/apps/29-fee/types"
 	ibcexported "github.com/cosmos/ibc-go/v9/modules/core/exported"
@@ -94,12 +98,10 @@ import (
 	ibctransferkeeper "github.com/cosmos/ibc-go/v9/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v9/modules/apps/transfer/types"
 	ibcporttypes "github.com/cosmos/ibc-go/v9/modules/core/05-port/types"
-	ibchost "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v9/modules/core/keeper"
 	ibctesting "github.com/cosmos/ibc-go/v9/testing"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmos "github.com/tendermint/tendermint/libs/os"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 // maccPerms is short for module account permissions. It is a map from module
@@ -147,27 +149,28 @@ type App struct {
 	memKeys     map[string]*storetypes.MemoryStoreKey
 
 	// keepers
-	AccountsKeeper  accounts.Keeper
-	AuthKeeper      authkeeper.AccountKeeper
-	BankKeeper      bankkeeper.Keeper
-	AuthzKeeper     authzkeeper.Keeper
-	ConsensusKeeper consensuskeeper.Keeper
-	StakingKeeper   *stakingkeeper.Keeper
-	SlashingKeeper  slashingkeeper.Keeper
-	MintKeeper      mintkeeper.Keeper
-	DistrKeeper     distrkeeper.Keeper
-	GovKeeper       *govkeeper.Keeper
-	ParamsKeeper    paramskeeper.Keeper // To be removed after successful migration
-	PoolKeeper      poolkeeper.Keeper
-	UpgradeKeeper   *upgradekeeper.Keeper // This is included purely for the IBC Keeper. It is not used for upgrading
-	SignalKeeper    signal.Keeper
-	IBCKeeper       *ibckeeper.Keeper // IBCKeeper must be a pointer in the app, so we can SetRouter on it correctly
-	IBCFeeKeeper    ibcfeekeeper.Keeper
-	EvidenceKeeper  evidencekeeper.Keeper
-	TransferKeeper  ibctransferkeeper.Keeper
-	FeeGrantKeeper  feegrantkeeper.Keeper
-	ICAHostKeeper   icahostkeeper.Keeper
-	// PacketForwardKeeper *packetforwardkeeper.Keeper // TODO: deprecated by ibc-go/v9 ?
+	AccountsKeeper      accounts.Keeper
+	AuthKeeper          authkeeper.AccountKeeper
+	BankKeeper          bankkeeper.Keeper
+	AuthzKeeper         authzkeeper.Keeper
+	ConsensusKeeper     consensuskeeper.Keeper
+	StakingKeeper       *stakingkeeper.Keeper
+	SlashingKeeper      slashingkeeper.Keeper
+	MintKeeper          mintkeeper.Keeper
+	DistrKeeper         distrkeeper.Keeper
+	GovKeeper           *govkeeper.Keeper
+	ParamsKeeper        paramskeeper.Keeper // To be removed after successful migration
+	PoolKeeper          poolkeeper.Keeper
+	UpgradeKeeper       *upgradekeeper.Keeper // This is included purely for the IBC Keeper. It is not used for upgrading
+	SignalKeeper        signal.Keeper
+	IBCKeeper           *ibckeeper.Keeper // IBCKeeper must be a pointer in the app, so we can SetRouter on it correctly
+	IBCFeeKeeper        ibcfeekeeper.Keeper
+	ICAControllerKeeper icacontrollerkeeper.Keeper
+	EvidenceKeeper      evidencekeeper.Keeper
+	TransferKeeper      ibctransferkeeper.Keeper
+	FeeGrantKeeper      feegrantkeeper.Keeper
+	ICAHostKeeper       icahostkeeper.Keeper
+	// PacketForwardKeeper *packetforwardkeeper.Keeper // TODO: deprecated by ibc-go/v10 ?
 	BlobKeeper       blobkeeper.Keeper
 	BlobstreamKeeper blobstreamkeeper.Keeper
 
@@ -231,7 +234,7 @@ func New(
 	baseApp.SetInterfaceRegistry(interfaceRegistry)
 
 	keys := storetypes.NewKVStoreKeys(allStoreKeys()...)
-	envFactory := &moduleEnvFactory{logger: logger, keys: keys}
+	envFactory := &moduleEnvFactory{logger: logger, keys: keys, routerProvider: baseApp}
 	tkeys := storetypes.NewTransientStoreKeys(paramstypes.TStoreKey)
 
 	app := &App{
@@ -264,12 +267,7 @@ func New(
 
 	app.AccountsKeeper, err = accounts.NewKeeper(
 		appCodec,
-		runtime.NewEnvironment(
-			runtime.NewKVStoreService(keys[accounts.StoreKey]),
-			logger.With(log.ModuleKey, "x/accounts"),
-			runtime.EnvWithMsgRouterService(app.MsgServiceRouter()),
-			runtime.EnvWithQueryRouterService(app.GRPCQueryRouter()),
-		),
+		envFactory.makeWithRouters(accounts.ModuleName, accounts.StoreKey),
 		signingCtx.AddressCodec(),
 		appCodec.InterfaceRegistry(),
 		txDecoder,
@@ -300,20 +298,13 @@ func New(
 		govModuleAddr,
 	)
 	app.AuthzKeeper = authzkeeper.NewKeeper(
-		runtime.NewEnvironment(
-			runtime.NewKVStoreService(keys[authzkeeper.StoreKey]), logger.With(log.ModuleKey, "x/authz"),
-			runtime.EnvWithMsgRouterService(app.MsgServiceRouter()),
-			runtime.EnvWithQueryRouterService(app.GRPCQueryRouter())),
+		envFactory.makeWithRouters(authtypes.ModuleName, authzkeeper.StoreKey),
 		appCodec,
 		app.AuthKeeper,
 	)
 	app.StakingKeeper = stakingkeeper.NewKeeper(
 		appCodec,
-		runtime.NewEnvironment(
-			runtime.NewKVStoreService(keys[stakingtypes.StoreKey]),
-			logger.With(log.ModuleKey, "x/staking"),
-			runtime.EnvWithMsgRouterService(app.MsgServiceRouter()),
-			runtime.EnvWithQueryRouterService(app.GRPCQueryRouter())),
+		envFactory.makeWithRouters(stakingtypes.ModuleName, stakingtypes.StoreKey),
 		app.AuthKeeper,
 		app.BankKeeper,
 		app.ConsensusKeeper,
@@ -363,10 +354,7 @@ func New(
 	// upgrade. This keeper is not used for the actual upgrades but merely for compatibility reasons. Ideally IBC has their own upgrade module
 	// for performing IBC based upgrades. Note, as we use rolling upgrades, IBC technically never needs this functionality.
 	app.UpgradeKeeper = upgradekeeper.NewKeeper(
-		runtime.NewEnvironment(
-			runtime.NewKVStoreService(keys[upgradetypes.StoreKey]), logger.With(log.ModuleKey, "x/upgrade"),
-			runtime.EnvWithMsgRouterService(app.MsgServiceRouter()),
-			runtime.EnvWithQueryRouterService(app.GRPCQueryRouter())),
+		envFactory.makeWithRouters(upgradetypes.ModuleName, upgradetypes.StoreKey),
 		nil, appCodec, "", app.BaseApp, govModuleAddr, app.ConsensusKeeper)
 
 	app.BlobstreamKeeper = *blobstreamkeeper.NewKeeper(
@@ -382,13 +370,12 @@ func New(
 		stakingtypes.NewMultiStakingHooks(
 			app.DistrKeeper.Hooks(),
 			app.SlashingKeeper.Hooks(),
-			// TODO: pending update
-			//app.BlobstreamKeeper.Hooks(),
+			app.BlobstreamKeeper.Hooks(),
 		),
 	)
 
-	// TODO:
-	//app.SignalKeeper = signal.NewKeeper(appCodec, keys[signaltypes.StoreKey], app.StakingKeeper)
+	app.SignalKeeper = signal.NewKeeper(
+		envFactory.make(signaltypes.ModuleName, signaltypes.StoreKey), appCodec, &signalStakingWrapper{app.StakingKeeper})
 
 	app.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
@@ -398,9 +385,21 @@ func New(
 		govModuleAddr,
 	)
 
+	// ICA Controller keeper
+	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
+		appCodec,
+		runtime.NewEnvironment(
+			runtime.NewKVStoreService(keys[icacontrollertypes.StoreKey]), logger.With(log.ModuleKey, "x/icacontroller"),
+			runtime.EnvWithMsgRouterService(app.MsgServiceRouter())),
+		app.GetSubspace(icacontrollertypes.SubModuleName),
+		app.IBCFeeKeeper, // use ics29 fee as ics4Wrapper in middleware stack
+		app.IBCKeeper.ChannelKeeper,
+		govModuleAddr,
+	)
+
 	app.ICAHostKeeper = icahostkeeper.NewKeeper(
 		appCodec,
-		envFactory.make(icahosttypes.SubModuleName, icahosttypes.StoreKey), // TODO add msg router
+		envFactory.makeWithRouters(icahosttypes.SubModuleName, icahosttypes.StoreKey),
 		app.GetSubspace(icahosttypes.SubModuleName),
 		app.IBCKeeper.ChannelKeeper, // ICS4Wrapper
 		app.IBCKeeper.ChannelKeeper,
@@ -417,7 +416,11 @@ func New(
 		Example of setting gov params:
 		govConfig.MaxMetadataLen = 10000
 	*/
-	app.GovKeeper = govkeeper.NewKeeper(appCodec, runtime.NewEnvironment(runtime.NewKVStoreService(keys[govtypes.StoreKey]), logger.With(log.ModuleKey, "x/gov"), runtime.EnvWithMsgRouterService(app.MsgServiceRouter()), runtime.EnvWithQueryRouterService(app.GRPCQueryRouter())), app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.PoolKeeper, govConfig, govModuleAddr)
+	app.GovKeeper = govkeeper.NewKeeper(appCodec,
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[govtypes.StoreKey]), logger.With(log.ModuleKey, "x/gov"),
+			runtime.EnvWithMsgRouterService(app.MsgServiceRouter()),
+			runtime.EnvWithQueryRouterService(app.GRPCQueryRouter())),
+		app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.PoolKeeper, govConfig, govModuleAddr)
 
 	// Set legacy router for backwards compatibility with gov v1beta1
 	app.GovKeeper.SetLegacyRouter(govRouter)
@@ -508,8 +511,9 @@ func New(
 	// order begin block, end block and init genesis
 	app.setModuleOrder()
 
-	app.QueryRouter().AddRoute(proof.TxInclusionQueryPath, proof.QueryTxInclusionProof)
-	app.QueryRouter().AddRoute(proof.ShareInclusionQueryPath, proof.QueryShareInclusionProof)
+	// TODO: How to support this in 0.52?
+	// app.QueryRouter().AddRoute(proof.TxInclusionQueryPath, proof.QueryTxInclusionProof)
+	// app.QueryRouter().AddRoute(proof.ShareInclusionQueryPath, proof.QueryShareInclusionProof)
 
 	app.configurator = module.NewConfigurator(app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter())
 	app.manager.RegisterServices(app.configurator)
@@ -540,8 +544,9 @@ func New(
 	))
 	app.SetPostHandler(posthandler.New())
 
-	app.SetMigrateStoreFn(app.migrateCommitStore)
-	app.SetMigrateModuleFn(app.migrateModules)
+	// TODO: migration related, delaying implemenation for now
+	// app.SetMigrateStoreFn(app.migrateCommitStore)
+	// app.SetMigrateModuleFn(app.migrateModules)
 
 	// assert that keys are present for all supported versions
 	app.assertAllKeysArePresent()
@@ -560,7 +565,7 @@ func (app *App) Name() string { return app.BaseApp.Name() }
 
 // BeginBlocker application updates every begin block
 func (app *App) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
-	if ctx.BlockHeight() == app.upgradeHeightV2 {
+	if ctx.BlockHeader().Height == app.upgradeHeightV2 {
 		app.BaseApp.Logger().Info("upgraded from app version 1 to 2")
 	}
 	return app.manager.BeginBlock(ctx)
@@ -568,7 +573,10 @@ func (app *App) BeginBlocker(ctx sdk.Context) (sdk.BeginBlock, error) {
 
 // EndBlocker executes application updates at the end of every block.
 func (app *App) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
-	res := app.manager.EndBlock(ctx)
+	res, err := app.manager.EndBlock(ctx)
+	if err != nil {
+		return sdk.EndBlock{}, err
+	}
 	currentVersion, err := app.AppVersion(ctx)
 	if err != nil {
 		panic(err)
@@ -576,7 +584,7 @@ func (app *App) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 	// For v1 only we upgrade using an agreed upon height known ahead of time
 	if currentVersion == v1 {
 		// check that we are at the height before the upgrade
-		if req.Height == app.upgradeHeightV2-1 {
+		if ctx.BlockHeader().Height == app.upgradeHeightV2-1 {
 			app.BaseApp.Logger().Info(fmt.Sprintf("upgrading from app version %v to 2", currentVersion))
 			if err = app.SetAppVersion(ctx, v2); err != nil {
 				panic(err)
@@ -593,28 +601,26 @@ func (app *App) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 			app.SignalKeeper.ResetTally(ctx)
 		}
 	}
-	res.Timeouts.TimeoutCommit = app.getTimeoutCommit(currentVersion)
-	res.Timeouts.TimeoutPropose = appconsts.GetTimeoutPropose(currentVersion)
-	return res
+	// REVIEW: these are moved to YAML, ok to delete?
+	// res.Timeouts.TimeoutCommit = app.getTimeoutCommit(currentVersion)
+	// res.Timeouts.TimeoutPropose = appconsts.GetTimeoutPropose(currentVersion)
+	return res, nil
 }
 
 // migrateCommitStore tells the baseapp during a version upgrade, which stores to add and which
 // stores to remove
-func (app *App) migrateCommitStore(fromVersion, toVersion uint64) (baseapp.StoreMigrations, error) {
+func (app *App) migrateCommitStore(fromVersion, toVersion uint64) (*storetypes.StoreUpgrades, error) {
 	oldStoreKeys := app.keyVersions[fromVersion]
 	newStoreKeys := app.keyVersions[toVersion]
-	result := baseapp.StoreMigrations{
-		Added:   make(map[string]*storetypes.KVStoreKey),
-		Deleted: make(map[string]*storetypes.KVStoreKey),
-	}
+	result := &storetypes.StoreUpgrades{}
 	for _, oldKey := range oldStoreKeys {
 		if !slices.Contains(newStoreKeys, oldKey) {
-			result.Deleted[oldKey] = app.keys[oldKey]
+			result.Deleted = append(result.Deleted, oldKey)
 		}
 	}
 	for _, newKey := range newStoreKeys {
 		if !slices.Contains(oldStoreKeys, newKey) {
-			result.Added[newKey] = app.keys[newKey]
+			result.Added = append(result.Added, newKey)
 		}
 	}
 	return result, nil
@@ -631,30 +637,35 @@ func (app *App) migrateModules(ctx sdk.Context, fromVersion, toVersion uint64) e
 // store.
 //
 // Side-effect: calls baseapp.Init()
-func (app *App) Info(req abci.RequestInfo) abci.ResponseInfo {
+func (app *App) Info(req *abci.InfoRequest) (*abci.InfoResponse, error) {
 	if height := app.LastBlockHeight(); height > 0 {
 		ctx, err := app.CreateQueryContext(height, false)
 		if err != nil {
 			panic(err)
 		}
-		appVersion := app.GetAppVersionFromParamStore(ctx)
-		if appVersion > 0 {
-			app.SetAppVersion(ctx, appVersion)
-		} else {
+		appVersion, err := app.AppVersion(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if appVersion == 0 {
 			app.SetAppVersion(ctx, v1)
 		}
 	}
 
-	resp := app.BaseApp.Info(req)
+	resp, err := app.BaseApp.Info(req)
+	if err != nil {
+		return nil, err
+	}
 	// mount the stores for the provided app version
 	if resp.AppVersion > 0 && !app.IsSealed() {
 		app.mountKeysAndInit(resp.AppVersion)
 	}
 
-	resp.Timeouts.TimeoutCommit = app.getTimeoutCommit(resp.AppVersion)
-	resp.Timeouts.TimeoutPropose = appconsts.GetTimeoutPropose(resp.AppVersion)
+	// REVIEW: these were moved to YAML, okay to delete?
+	// resp.Timeouts.TimeoutCommit = app.getTimeoutCommit(resp.AppVersion)
+	// resp.Timeouts.TimeoutPropose = appconsts.GetTimeoutPropose(resp.AppVersion)
 
-	return resp
+	return resp, nil
 }
 
 // InitChain implements the ABCI interface. This method is a wrapper around
@@ -662,38 +673,41 @@ func (app *App) Info(req abci.RequestInfo) abci.ResponseInfo {
 // store.
 //
 // Side-effect: calls baseapp.Init()
-func (app *App) InitChain(req abci.RequestInitChain) (res abci.ResponseInitChain) {
+func (app *App) InitChain(req *abci.InitChainRequest) (res *abci.InitChainResponse, err error) {
 	req = setDefaultAppVersion(req)
-	appVersion := req.ConsensusParams.Version.AppVersion
-	// mount the stores for the provided app version if it has not already been mounted
-	if app.AppVersion() == 0 && !app.IsSealed() {
+	appVersion := req.ConsensusParams.Version.App
+	ctx := context.Background()
+	av, err := app.AppVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if av == 0 && !app.IsSealed() {
 		app.mountKeysAndInit(appVersion)
 	}
 
-	res = app.BaseApp.InitChain(req)
+	res, err = app.BaseApp.InitChain(req)
+	if err != nil {
+		return nil, err
+	}
 
-	ctx := app.NewContext(false, tmproto.Header{})
 	if appVersion != v1 {
-		app.SetInitialAppVersionInConsensusParams(ctx, appVersion)
 		app.SetAppVersion(ctx, appVersion)
 	}
-	res.Timeouts.TimeoutCommit = app.getTimeoutCommit(appVersion)
-	res.Timeouts.TimeoutPropose = appconsts.GetTimeoutPropose(appVersion)
-	return res
+	return res, nil
 }
 
 // setDefaultAppVersion sets the default app version in the consensus params if
 // it was 0. This is needed because chains (e.x. mocha-4) did not explicitly set
 // an app version in genesis.json.
-func setDefaultAppVersion(req abci.RequestInitChain) abci.RequestInitChain {
+func setDefaultAppVersion(req *abci.InitChainRequest) *abci.InitChainRequest {
 	if req.ConsensusParams == nil {
 		panic("no consensus params set")
 	}
 	if req.ConsensusParams.Version == nil {
 		panic("no version set in consensus params")
 	}
-	if req.ConsensusParams.Version.AppVersion == 0 {
-		req.ConsensusParams.Version.AppVersion = v1
+	if req.ConsensusParams.Version.App == 0 {
+		req.ConsensusParams.Version.App = v1
 	}
 	return req
 }
@@ -714,11 +728,15 @@ func (app *App) mountKeysAndInit(appVersion uint64) {
 func (app *App) InitChainer(ctx sdk.Context, req *abci.InitChainRequest) (*abci.InitChainResponse, error) {
 	var genesisState GenesisState
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
-		panic(err)
+		return nil, err
 	}
-	appVersion := req.ConsensusParams.Version.AppVersion
-	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.manager.GetVersionMap(appVersion))
-	return app.manager.InitGenesis(ctx, app.appCodec, genesisState, appVersion)
+	appVersion := req.ConsensusParams.Version.App
+	versionMap, err := app.manager.GetVersionMap(appVersion)
+	if err != nil {
+		return nil, err
+	}
+	app.UpgradeKeeper.SetModuleVersionMap(ctx, versionMap)
+	return app.manager.InitGenesis(ctx, genesisState, appVersion)
 }
 
 // LoadHeight loads a particular height
@@ -837,8 +855,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, _ config.APIConfig) {
 	// Register new tx routes from grpc-gateway.
 	authtx.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 	// Register new tendermint queries routes from grpc-gateway.
-	// TODO cometservice?
-	// tmservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
+	app.RegisterTendermintService(clientCtx)
 	// Register node gRPC service for grpc-gateway.
 	nodeservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 	ModuleBasics.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
@@ -853,28 +870,34 @@ func (app *App) RegisterTxService(clientCtx client.Context) {
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *App) RegisterTendermintService(clientCtx client.Context) {
-	// TODO comet service?
-	// tmservice.RegisterTendermintService(clientCtx, app.BaseApp.GRPCQueryRouter(), app.interfaceRegistry, app.Query)
+	cmtApp := server.NewCometABCIWrapper(app)
+	cmtservice.RegisterTendermintService(
+		clientCtx,
+		app.BaseApp.GRPCQueryRouter(),
+		app.interfaceRegistry,
+		cmtApp.Query,
+	)
 }
 
-func (app *App) RegisterNodeService(clientCtx client.Context) {
-	nodeservice.RegisterNodeService(clientCtx, app.GRPCQueryRouter())
+func (app *App) RegisterNodeService(clientCtx client.Context, cfg config.Config) {
+	nodeservice.RegisterNodeService(clientCtx, app.GRPCQueryRouter(), cfg)
 }
 
+// TODO: To be moved to antehandler
 // BlockedParams returns the params that require a hardfork to change, and
 // cannot be changed via governance.
-func (app *App) BlockedParams() [][2]string {
-	return [][2]string{
-		// bank.SendEnabled
-		{banktypes.ModuleName, string(banktypes.KeySendEnabled)},
-		// staking.UnbondingTime
-		{stakingtypes.ModuleName, string(stakingtypes.KeyUnbondingTime)},
-		// staking.BondDenom
-		{stakingtypes.ModuleName, string(stakingtypes.KeyBondDenom)},
-		// consensus.validator.PubKeyTypes
-		{baseapp.Paramspace, string(baseapp.ParamStoreKeyValidatorParams)},
-	}
-}
+// func (app *App) BlockedParams() [][2]string {
+// 	return [][2]string{
+// 		// bank.SendEnabled
+// 		{banktypes.ModuleName, string(banktypes.KeySendEnabled)},
+// 		// staking.UnbondingTime
+// 		{stakingtypes.ModuleName, string(stakingtypes.KeyUnbondingTime)},
+// 		// staking.BondDenom
+// 		{stakingtypes.ModuleName, string(stakingtypes.KeyBondDenom)},
+// 		// consensus.validator.PubKeyTypes
+// 		{baseapp.Paramspace, string(baseapp.ParamStoreKeyValidatorParams)},
+// 	}
+// }
 
 // initParamsKeeper initializes the params keeper and its subspaces.
 func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
@@ -886,9 +909,9 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(minttypes.ModuleName)
 	paramsKeeper.Subspace(distrtypes.ModuleName)
 	paramsKeeper.Subspace(slashingtypes.ModuleName)
-	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govv1beta2.ParamKeyTable())
+	// paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govv1beta2.ParamKeyTable())
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
-	paramsKeeper.Subspace(ibchost.ModuleName)
+	paramsKeeper.Subspace(ibcexported.ModuleName)
 	paramsKeeper.Subspace(icahosttypes.SubModuleName)
 	paramsKeeper.Subspace(blobtypes.ModuleName)
 	paramsKeeper.Subspace(blobstreamtypes.ModuleName)
@@ -896,57 +919,6 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	// paramsKeeper.Subspace(packetforwardtypes.ModuleName)
 
 	return paramsKeeper
-}
-
-func (app *App) InitializeAppVersion(ctx sdk.Context) {
-	appVersion := app.GetAppVersionFromParamStore(ctx)
-	if appVersion == 0 {
-		// if the param store does not have an app version set, default to v1
-		app.SetAppVersion(ctx, v1)
-	} else {
-		app.SetAppVersion(ctx, appVersion)
-	}
-}
-
-// OfferSnapshot is a wrapper around the baseapp's OfferSnapshot method. It is
-// needed to mount stores for the appropriate app version.
-func (app *App) OfferSnapshot(req abci.RequestOfferSnapshot) abci.ResponseOfferSnapshot {
-	if app.IsSealed() {
-		// If the app is sealed, keys have already been mounted so this can
-		// delegate to the baseapp's OfferSnapshot.
-		return app.BaseApp.OfferSnapshot(req)
-	}
-
-	app.Logger().Info("offering snapshot", "height", req.Snapshot.Height, "app_version", req.AppVersion)
-	if req.AppVersion != 0 {
-		if !isSupportedAppVersion(req.AppVersion) {
-			app.Logger().Info("rejecting snapshot because unsupported app version", "app_version", req.AppVersion)
-			return abci.ResponseOfferSnapshot{
-				Result: abci.ResponseOfferSnapshot_REJECT,
-			}
-		}
-
-		app.Logger().Info("mounting keys for snapshot", "app_version", req.AppVersion)
-		app.mountKeysAndInit(req.AppVersion)
-		return app.BaseApp.OfferSnapshot(req)
-	}
-
-	// If the app version is not set in the snapshot, this falls back to inferring the app version based on the upgrade height.
-	if app.upgradeHeightV2 == 0 {
-		app.Logger().Info("v2 upgrade height not set, assuming app version 2")
-		app.mountKeysAndInit(v2)
-		return app.BaseApp.OfferSnapshot(req)
-	}
-
-	if req.Snapshot.Height >= uint64(app.upgradeHeightV2) {
-		app.Logger().Info("snapshot height is greater than or equal to upgrade height, assuming app version 2")
-		app.mountKeysAndInit(v2)
-		return app.BaseApp.OfferSnapshot(req)
-	}
-
-	app.Logger().Info("snapshot height is less than upgrade height, assuming app version 1")
-	app.mountKeysAndInit(v1)
-	return app.BaseApp.OfferSnapshot(req)
 }
 
 func isSupportedAppVersion(appVersion uint64) bool {
@@ -964,8 +936,20 @@ func (app *App) getTimeoutCommit(appVersion uint64) time.Duration {
 }
 
 type moduleEnvFactory struct {
-	keys   map[string]*storetypes.KVStoreKey
-	logger log.Logger
+	keys           map[string]*storetypes.KVStoreKey
+	logger         log.Logger
+	routerProvider interface {
+		MsgServiceRouter() *baseapp.MsgServiceRouter
+		GRPCQueryRouter() *baseapp.GRPCQueryRouter
+	}
+}
+
+type signalStakingWrapper struct {
+	*stakingkeeper.Keeper
+}
+
+func (s *signalStakingWrapper) GetLastTotalPower(ctx context.Context) (math.Int, error) {
+	return s.Keeper.LastTotalPower.Get(ctx)
 }
 
 func (f *moduleEnvFactory) make(
@@ -980,4 +964,28 @@ func (f *moduleEnvFactory) make(
 		runtime.NewKVStoreService(kvKey),
 		f.logger.With(log.ModuleKey, name),
 	)
+}
+
+func (f *moduleEnvFactory) makeWithRouters(
+	name string,
+	storeKey string,
+) appmodulev2.Environment {
+	kvKey, ok := f.keys[storeKey]
+	if !ok {
+		panic(fmt.Sprintf("store key %s not found", storeKey))
+	}
+	return runtime.NewEnvironment(
+		runtime.NewKVStoreService(kvKey),
+		f.logger.With(log.ModuleKey, name),
+		runtime.EnvWithMsgRouterService(f.routerProvider.MsgServiceRouter()),
+		runtime.EnvWithQueryRouterService(f.routerProvider.GRPCQueryRouter()),
+	)
+}
+
+// ValidatorKeyProvider returns a function that generates a validator key
+// Supported key types are those supported by Comet: ed25519, secp256k1, bls12-381
+func (app *App) ValidatorKeyProvider() runtime.KeyGenF {
+	return func() (cmtcrypto.PrivKey, error) {
+		return cmted25519.GenPrivKey(), nil
+	}
 }

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -9,41 +9,46 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
 	blobtypes "github.com/celestiaorg/celestia-app/v3/x/blob/types"
 	blobtx "github.com/celestiaorg/go-square/v2/tx"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	abci "github.com/tendermint/tendermint/abci/types"
+	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 )
 
 // CheckTx implements the ABCI interface and executes a tx in CheckTx mode. This
 // method wraps the default Baseapp's method so that it can parse and check
 // transactions that contain blobs.
-func (app *App) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
+func (app *App) CheckTx(req *abci.CheckTxRequest) (*abci.CheckTxResponse, error) {
 	tx := req.Tx
 
+	ctx := app.NewContext(true)
+	appVersion, err := app.AppVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// all txs must be less than or equal to the max tx size limit
-	maxTxSize := appconsts.MaxTxSize(app.AppVersion())
+	maxTxSize := appconsts.MaxTxSize(appVersion)
 	currentTxSize := len(tx)
 	if currentTxSize > maxTxSize {
-		return sdkerrors.ResponseCheckTxWithEvents(errors.Wrapf(apperr.ErrTxExceedsMaxSize, "tx size %d bytes is larger than the application's configured MaxTxSize of %d bytes for version %d", currentTxSize, maxTxSize, app.AppVersion()), 0, 0, []abci.Event{}, false)
+		return responseCheckTxWithEvents(errors.Wrapf(apperr.ErrTxExceedsMaxSize, "tx size %d bytes is larger than the application's configured MaxTxSize of %d bytes for version %d", currentTxSize, maxTxSize, appVersion), 0, 0, []abci.Event{}, false), nil
 	}
 
 	// check if the transaction contains blobs
 	btx, isBlob, err := blobtx.UnmarshalBlobTx(tx)
 	if isBlob && err != nil {
-		return sdkerrors.ResponseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false)
+		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 	}
 
 	if !isBlob {
 		// reject transactions that can't be decoded
 		sdkTx, err := app.txConfig.TxDecoder()(tx)
 		if err != nil {
-			return sdkerrors.ResponseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false)
+			return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 		}
 		// reject transactions that have a MsgPFB but no blobs attached to the tx
 		for _, msg := range sdkTx.GetMsgs() {
 			if _, ok := msg.(*blobtypes.MsgPayForBlobs); !ok {
 				continue
 			}
-			return sdkerrors.ResponseCheckTxWithEvents(blobtypes.ErrNoBlobs, 0, 0, []abci.Event{}, false)
+			return responseCheckTxWithEvents(blobtypes.ErrNoBlobs, 0, 0, []abci.Event{}, false), nil
 		}
 		// don't do anything special if we have a normal transaction
 		return app.BaseApp.CheckTx(req)
@@ -51,17 +56,28 @@ func (app *App) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 
 	switch req.Type {
 	// new transactions must be checked in their entirety
-	case abci.CheckTxType_New:
-		appVersion := app.AppVersion()
-		err := blobtypes.ValidateBlobTx(app.txConfig, btx, appconsts.SubtreeRootThreshold(appVersion), appVersion)
+	case abci.CHECK_TX_TYPE_CHECK:
+		err = blobtypes.ValidateBlobTx(app.txConfig, btx, appconsts.SubtreeRootThreshold(appVersion), appVersion)
 		if err != nil {
-			return sdkerrors.ResponseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false)
+			return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 		}
-	case abci.CheckTxType_Recheck:
+	case abci.CHECK_TX_TYPE_RECHECK:
 	default:
 		panic(fmt.Sprintf("unknown RequestCheckTx type: %s", req.Type))
 	}
 
 	req.Tx = btx.Tx
 	return app.BaseApp.CheckTx(req)
+}
+
+func responseCheckTxWithEvents(err error, gw, gu uint64, events []abci.Event, debug bool) *abci.CheckTxResponse {
+	space, code, log := errors.ABCIInfo(err, debug)
+	return &abci.CheckTxResponse{
+		Codespace: space,
+		Code:      code,
+		Log:       log,
+		GasWanted: int64(gw),
+		GasUsed:   int64(gu),
+		Events:    events,
+	}
 }

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"cosmossdk.io/core/appmodule"
-	pooltypes "cosmossdk.io/x/protocolpool/types"
 	"fmt"
+
+	pooltypes "cosmossdk.io/x/protocolpool/types"
 	ibcfeetypes "github.com/cosmos/ibc-go/v9/modules/apps/29-fee/types"
 
 	"cosmossdk.io/core/comet"
@@ -56,7 +56,6 @@ import (
 	"github.com/cosmos/ibc-go/v9/modules/apps/transfer"
 	ibctransfertypes "github.com/cosmos/ibc-go/v9/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v9/modules/core"
-	ibchost "github.com/cosmos/ibc-go/v9/modules/core/24-host"
 	ibcexported "github.com/cosmos/ibc-go/v9/modules/core/exported"
 )
 
@@ -190,7 +189,7 @@ func (app *App) setupModuleManager(
 		// 	FromVersion: v2, ToVersion: v3,
 		// },
 		{
-			Module:      ica.NewAppModule(nil, &app.ICAHostKeeper),
+			Module:      ica.NewAppModule(nil, &app.ICAControllerKeeper, &app.ICAHostKeeper),
 			FromVersion: v2, ToVersion: v3,
 		},
 	})
@@ -315,7 +314,7 @@ func versionedStoreKeys() map[uint64][]string {
 			evidencetypes.StoreKey,
 			feegrant.StoreKey,
 			govtypes.StoreKey,
-			ibchost.StoreKey,
+			ibcexported.StoreKey,
 			ibctransfertypes.StoreKey,
 			minttypes.StoreKey,
 			slashingtypes.StoreKey,
@@ -331,7 +330,7 @@ func versionedStoreKeys() map[uint64][]string {
 			evidencetypes.StoreKey,
 			feegrant.StoreKey,
 			govtypes.StoreKey,
-			ibchost.StoreKey,
+			ibcexported.StoreKey,
 			ibctransfertypes.StoreKey,
 			icahosttypes.StoreKey, // added in v2
 			minttypes.StoreKey,
@@ -350,7 +349,7 @@ func versionedStoreKeys() map[uint64][]string {
 			evidencetypes.StoreKey,
 			feegrant.StoreKey,
 			govtypes.StoreKey,
-			ibchost.StoreKey,
+			ibcexported.StoreKey,
 			ibctransfertypes.StoreKey,
 			icahosttypes.StoreKey,
 			minttypes.StoreKey,

--- a/app/modules.go
+++ b/app/modules.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"cosmossdk.io/core/appmodule"
+	pooltypes "cosmossdk.io/x/protocolpool/types"
 	"fmt"
+	ibcfeetypes "github.com/cosmos/ibc-go/v9/modules/apps/29-fee/types"
 
 	"cosmossdk.io/core/comet"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -180,7 +182,7 @@ func (app *App) setupModuleManager(
 			FromVersion: v2, ToVersion: v3,
 		},
 		{
-			Module:      minfee.NewAppModule(app.ParamsKeeper),
+			Module:      minfee.NewAppModule(app.appCodec, app.ParamsKeeper),
 			FromVersion: v2, ToVersion: v3,
 		},
 		// {
@@ -221,6 +223,7 @@ func (app *App) setModuleOrder() {
 		signaltypes.ModuleName,
 		minfee.ModuleName,
 		icatypes.ModuleName,
+		ibcfeetypes.ModuleName,
 		// packetforwardtypes.ModuleName,
 	)
 
@@ -229,6 +232,7 @@ func (app *App) setModuleOrder() {
 		stakingtypes.ModuleName,
 		minttypes.ModuleName,
 		distrtypes.ModuleName,
+		pooltypes.ModuleName,
 		slashingtypes.ModuleName,
 		evidencetypes.ModuleName,
 		ibcexported.ModuleName,
@@ -246,6 +250,7 @@ func (app *App) setModuleOrder() {
 		minfee.ModuleName,
 		// packetforwardtypes.ModuleName,
 		icatypes.ModuleName,
+		ibcfeetypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are
@@ -256,6 +261,7 @@ func (app *App) setModuleOrder() {
 		authtypes.ModuleName,
 		banktypes.ModuleName,
 		distrtypes.ModuleName,
+		pooltypes.ModuleName,
 		stakingtypes.ModuleName,
 		slashingtypes.ModuleName,
 		govtypes.ModuleName,
@@ -274,6 +280,7 @@ func (app *App) setModuleOrder() {
 		signaltypes.ModuleName,
 		// packetforwardtypes.ModuleName,
 		icatypes.ModuleName,
+		ibcfeetypes.ModuleName,
 	)
 }
 
@@ -282,12 +289,14 @@ func allStoreKeys() []string {
 		authtypes.StoreKey, authzkeeper.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
 		govtypes.StoreKey, paramstypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
+		pooltypes.StoreKey,
 		evidencetypes.StoreKey,
 		blobstreamtypes.StoreKey,
 		ibctransfertypes.StoreKey,
 		ibcexported.StoreKey,
 		// packetforwardtypes.StoreKey,
 		icahosttypes.StoreKey,
+		ibcfeetypes.StoreKey,
 		signaltypes.StoreKey,
 		blobtypes.StoreKey,
 	}

--- a/app/posthandler/posthandler.go
+++ b/app/posthandler/posthandler.go
@@ -4,9 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// New returns a new posthandler chain. Note: the Cosmos SDK does not export a
-// type for PostHandler so the AnteHandler type is used.
-func New() sdk.AnteHandler {
-	postDecorators := []sdk.AnteDecorator{}
-	return sdk.ChainAnteDecorators(postDecorators...)
+// New returns a new posthandler chain.
+func New() sdk.PostHandler {
+	postDecorators := []sdk.PostDecorator{}
+	return sdk.ChainPostDecorators(postDecorators...)
 }

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -11,8 +11,8 @@ import (
 	square "github.com/celestiaorg/go-square/square"
 	squarev2 "github.com/celestiaorg/go-square/v2"
 	sharev2 "github.com/celestiaorg/go-square/v2/share"
+	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 	"github.com/cosmos/cosmos-sdk/telemetry"
-	abci "github.com/tendermint/tendermint/abci/types"
 	core "github.com/tendermint/tendermint/proto/tendermint/types"
 	version "github.com/tendermint/tendermint/proto/tendermint/version"
 )
@@ -22,7 +22,7 @@ import (
 // the proposal block and passes it back to tendermint via the BlockData. Panics
 // indicate a developer error and should immediately halt the node for
 // visibility and so they can be quickly resolved.
-func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+func (app *App) PrepareProposal(req *abci.PrepareProposalRequest) (*abci.PrepareProposalResponse, error) {
 	defer telemetry.MeasureSince(time.Now(), "prepare_proposal")
 	// Create a context using a branch of the state.
 	sdkCtx := app.NewProposalContext(core.Header{

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -14,16 +14,16 @@ import (
 	squarev2 "github.com/celestiaorg/go-square/v2"
 	sharev2 "github.com/celestiaorg/go-square/v2/share"
 	blobtx "github.com/celestiaorg/go-square/v2/tx"
+	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 const rejectedPropBlockLog = "Rejected proposal block:"
 
-func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.ResponseProcessProposal) {
+func (app *App) ProcessProposal(req *abci.ProcessProposalRequest) (resp *abci.ProcessProposalResponse, err error) {
 	defer telemetry.MeasureSince(time.Now(), "process_proposal")
 	// In the case of a panic resulting from an unexpected condition, it is
 	// better for the liveness of the network to catch it, log an error, and

--- a/binary.md
+++ b/binary.md
@@ -41,6 +41,10 @@ Replace directives to local copies of ibc-apps, until PFM is ugpraded.
   - [ ] Wrap x/mint within celestia mint for extending queries and keeping query path identical
 - [ ] Goal #11: Wire circuit breaker to block some (staking & bank) MsgUpdateParams now that x/paramfilter is removed
 
+### app.go checklist
+
+- [ ] Validate IBC wiring against [this simapp](https://github.com/cosmos/ibc-go/blob/main/simapp/app.go#L575). Dependent on PFM upgrade clarity.
+
 ### Progress
 
 ### 2025-01-07

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,30 @@ module github.com/celestiaorg/celestia-app/v3
 go 1.23.4
 
 require (
+	cosmossdk.io/api v0.8.0
+	cosmossdk.io/core v1.0.0
 	cosmossdk.io/errors v1.0.1
+	cosmossdk.io/log v1.5.0
 	cosmossdk.io/math v1.5.0
 	cosmossdk.io/store v1.10.0-rc.1.0.20241218084712-ca559989da43
-	cosmossdk.io/x/authz v0.0.0-00010101000000-000000000000
+	cosmossdk.io/x/accounts v0.2.0-rc.1
+	cosmossdk.io/x/accounts/defaults/base v0.2.0-rc.1
+	cosmossdk.io/x/accounts/defaults/lockup v0.2.0-rc.1
+	cosmossdk.io/x/accounts/defaults/multisig v0.2.0-rc.1
+	cosmossdk.io/x/authz v0.2.0-rc.1
 	cosmossdk.io/x/bank v0.2.0-rc.1
-	cosmossdk.io/x/distribution v0.0.0-20241218110910-47409028a73d
-	cosmossdk.io/x/evidence v0.0.0-00010101000000-000000000000
-	cosmossdk.io/x/feegrant v0.0.0-00010101000000-000000000000
-	cosmossdk.io/x/gov v0.0.0-20241218110910-47409028a73d
-	cosmossdk.io/x/group v0.0.0-00010101000000-000000000000
-	cosmossdk.io/x/mint v0.0.0-20240909082436-01c0e9ba3581
-	cosmossdk.io/x/params v0.0.0-00010101000000-000000000000
-	cosmossdk.io/x/slashing v0.0.0-00010101000000-000000000000
+	cosmossdk.io/x/consensus v0.2.0-rc.1
+	cosmossdk.io/x/distribution v0.2.0-rc.1
+	cosmossdk.io/x/evidence v0.2.0-rc.1
+	cosmossdk.io/x/feegrant v0.2.0-rc.1
+	cosmossdk.io/x/gov v0.2.0-rc.1
+	cosmossdk.io/x/group v0.2.0-rc.1
+	cosmossdk.io/x/mint v0.2.0-rc.1
+	cosmossdk.io/x/params v0.2.0-rc.1
+	cosmossdk.io/x/protocolpool v0.2.0-rc.1
+	cosmossdk.io/x/slashing v0.2.0-rc.1
 	cosmossdk.io/x/staking v0.2.0-rc.1
+	cosmossdk.io/x/tx v1.0.0
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/celestiaorg/blobstream-contracts/v3 v3.1.0
 	github.com/celestiaorg/go-square v1.1.1
@@ -25,6 +35,7 @@ require (
 	github.com/celestiaorg/nmt v0.22.2
 	github.com/celestiaorg/rsmt2d v0.14.0
 	github.com/cometbft/cometbft-db v1.0.1
+	github.com/cometbft/cometbft/api v1.0.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.53.0
 	github.com/cosmos/gogoproto v1.7.0
@@ -60,23 +71,13 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.1.13 // indirect
 	cloud.google.com/go/storage v1.43.0 // indirect
-	cosmossdk.io/api v0.8.0 // indirect
 	cosmossdk.io/client/v2 v2.0.0-beta.6 // indirect
 	cosmossdk.io/collections v1.0.0 // indirect
-	cosmossdk.io/core v1.0.0 // indirect
 	cosmossdk.io/core/testing v0.0.1 // indirect
 	cosmossdk.io/depinject v1.1.0 // indirect
-	cosmossdk.io/log v1.5.0 // indirect
 	cosmossdk.io/schema v1.0.0 // indirect
-	cosmossdk.io/x/accounts v0.0.0-20241218110910-47409028a73d // indirect
-	cosmossdk.io/x/accounts/defaults/base v0.2.0-rc.1 // indirect
-	cosmossdk.io/x/accounts/defaults/lockup v0.0.0-00010101000000-000000000000 // indirect
-	cosmossdk.io/x/accounts/defaults/multisig v0.0.0-00010101000000-000000000000 // indirect
-	cosmossdk.io/x/consensus v0.0.0-00010101000000-000000000000 // indirect
 	cosmossdk.io/x/epochs v0.0.0-20241218110910-47409028a73d // indirect
 	cosmossdk.io/x/nft v0.0.0-00010101000000-000000000000 // indirect
-	cosmossdk.io/x/protocolpool v0.0.0-20241218110910-47409028a73d // indirect
-	cosmossdk.io/x/tx v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
@@ -111,7 +112,6 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/cometbft/cometbft v1.0.0 // indirect
-	github.com/cometbft/cometbft/api v1.0.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
@@ -330,9 +330,9 @@ replace (
 	cosmossdk.io/x/staking => cosmossdk.io/x/staking v0.2.0-rc.1
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.2.0-rc.1
 	// checkout cosmos/cosmos-sdk at release/0.52.x
-	//github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250107080912-2bcc7678255f
+	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250110123731-13dddd3705fa
 	// local replace to be removed pending merge and backport of PRs mentioned in binary.md, ## Upstream section
-	github.com/cosmos/cosmos-sdk => ../cosmos-sdk
+	//github.com/cosmos/cosmos-sdk => ../cosmos-sdk
 	// ibc-go @ decc8ec9ae8eeda9cf3791d45d3005a6e929a990
 	github.com/cosmos/ibc-go/v9 => github.com/cosmos/ibc-go/v9 v9.0.0-20250105144616-decc8ec9ae8e
 	// ibc-apps @ d8473b7e9e39b5d35cd1024920c0878aec8775e6

--- a/go.mod
+++ b/go.mod
@@ -331,9 +331,7 @@ replace (
 	cosmossdk.io/x/upgrade => cosmossdk.io/x/upgrade v0.2.0-rc.1
 	// checkout cosmos/cosmos-sdk at release/0.52.x
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250110123731-13dddd3705fa
-	// local replace to be removed pending merge and backport of PRs mentioned in binary.md, ## Upstream section
-	//github.com/cosmos/cosmos-sdk => ../cosmos-sdk
-	// ibc-go @ decc8ec9ae8eeda9cf3791d45d3005a6e929a990
+	// ibc-go @ decc8ec9ae8eeda9cf3791d45d3005a6e929a990, this a v10 pre-release with a v9 module path
 	github.com/cosmos/ibc-go/v9 => github.com/cosmos/ibc-go/v9 v9.0.0-20250105144616-decc8ec9ae8e
 	// ibc-apps @ d8473b7e9e39b5d35cd1024920c0878aec8775e6
 	// github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v9 =>  github.com/01builders/ibc-apps/middleware/packet-forward-middleware/v9 v9.0.0-20250107215950-d8473b7e9e39

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/cosmos/cosmos-db v1.1.1 h1:FezFSU37AlBC8S98NlSagL76oqBRWq/prTPvFcEJNC
 github.com/cosmos/cosmos-db v1.1.1/go.mod h1:AghjcIPqdhSLP/2Z0yha5xPH3nLnskz81pBx3tcVSAw=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250107080912-2bcc7678255f h1:4m+m8vgkCc5mHS9d3oEMTq09HOjrSTDxt0PbTPY/E7A=
-github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250107080912-2bcc7678255f/go.mod h1:WDx31HY18jrJcTDbob6sRb5scTixBevLzmmfjkj/JCE=
+github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250110123731-13dddd3705fa h1:SpSqP3PMWRMRki3Jwdmh4ZyoxlSJbB6ERrLQEwXniYw=
+github.com/cosmos/cosmos-sdk v0.52.0-rc.1.0.20250110123731-13dddd3705fa/go.mod h1:WDx31HY18jrJcTDbob6sRb5scTixBevLzmmfjkj/JCE=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=

--- a/x/blobstream/keeper/keeper.go
+++ b/x/blobstream/keeper/keeper.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
+	"context"
 	"encoding/binary"
 
 	addresscodec "cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
-	storetypes "cosmossdk.io/store/types"
 	paramtypes "cosmossdk.io/x/params/types"
 	stakingtypes "cosmossdk.io/x/staking/types"
 	"github.com/celestiaorg/celestia-app/v3/x/blobstream/types"
@@ -22,7 +22,7 @@ type Keeper struct {
 	StakingKeeper StakingKeeper
 }
 
-func NewKeeper(env appmodule.Environment, cdc codec.BinaryCodec, storeKey storetypes.StoreKey, paramSpace paramtypes.Subspace, stakingKeeper StakingKeeper) *Keeper {
+func NewKeeper(env appmodule.Environment, cdc codec.BinaryCodec, paramSpace paramtypes.Subspace, stakingKeeper StakingKeeper) *Keeper {
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
@@ -60,9 +60,9 @@ func (k Keeper) DeserializeValidatorIterator(vals []byte) stakingtypes.ValAddres
 // StakingKeeper restricts the functionality of the bank keeper used in the blobstream
 // keeper
 type StakingKeeper interface {
-	GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, found bool)
-	GetBondedValidatorsByPower(ctx sdk.Context) []stakingtypes.Validator
-	GetLastValidatorPower(ctx sdk.Context, valAddr sdk.ValAddress) int64
+	GetValidator(ctx context.Context, addr sdk.ValAddress) (stakingtypes.Validator, error)
+	GetBondedValidatorsByPower(ctx context.Context) ([]stakingtypes.Validator, error)
+	GetLastValidatorPower(ctx context.Context, valAddr sdk.ValAddress) (int64, error)
 	ValidatorAddressCodec() addresscodec.Codec
 }
 

--- a/x/blobstream/keeper/keeper_valset.go
+++ b/x/blobstream/keeper/keeper_valset.go
@@ -104,9 +104,6 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 			return types.Valset{}, err
 		}
 		p := math.NewInt(lastValidatorPower)
-		if err != nil {
-			return types.Valset{}, errors.Wrap(err, types.ErrInvalidValAddress.Error())
-		}
 
 		evmAddress, exists := k.GetEVMAddress(ctx, valAddr)
 		if !exists {

--- a/x/blobstream/keeper/keeper_valset.go
+++ b/x/blobstream/keeper/keeper_valset.go
@@ -80,7 +80,10 @@ func (k Keeper) GetLatestUnBondingBlockHeight(ctx sdk.Context) uint64 {
 }
 
 func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
-	validators := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
+	validators, err := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
+	if err != nil {
+		return types.Valset{}, err
+	}
 	if len(validators) == 0 {
 		return types.Valset{}, types.ErrNoValidators
 	}
@@ -96,7 +99,14 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 			return types.Valset{}, errors.Wrap(err, types.ErrInvalidValAddress.Error())
 		}
 
-		p := math.NewInt(k.StakingKeeper.GetLastValidatorPower(ctx, valAddr))
+		lastValidatorPower, err := k.StakingKeeper.GetLastValidatorPower(ctx, valAddr)
+		if err != nil {
+			return types.Valset{}, err
+		}
+		p := math.NewInt(lastValidatorPower)
+		if err != nil {
+			return types.Valset{}, errors.Wrap(err, types.ErrInvalidValAddress.Error())
+		}
 
 		evmAddress, exists := k.GetEVMAddress(ctx, valAddr)
 		if !exists {

--- a/x/blobstream/keeper/msg_server.go
+++ b/x/blobstream/keeper/msg_server.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	sdkerrors "cosmossdk.io/errors"
+	"cosmossdk.io/errors"
 	"github.com/celestiaorg/celestia-app/v3/x/blobstream/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -38,7 +38,7 @@ func (k Keeper) RegisterEVMAddress(goCtx context.Context, msg *types.MsgRegister
 	}
 
 	if !k.IsEVMAddressUnique(ctx, evmAddr) {
-		return nil, sdkerrors.Wrapf(types.ErrEVMAddressAlreadyExists, "address %s", msg.EvmAddress)
+		return nil, errors.Wrapf(types.ErrEVMAddressAlreadyExists, "address %s", msg.EvmAddress)
 	}
 
 	k.SetEVMAddress(ctx, valAddr, evmAddr)

--- a/x/blobstream/keeper/msg_server.go
+++ b/x/blobstream/keeper/msg_server.go
@@ -3,8 +3,7 @@ package keeper
 import (
 	"context"
 
-	"cosmossdk.io/errors"
-	staking "cosmossdk.io/x/staking/types"
+	sdkerrors "cosmossdk.io/errors"
 	"github.com/celestiaorg/celestia-app/v3/x/blobstream/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -34,12 +33,12 @@ func (k Keeper) RegisterEVMAddress(goCtx context.Context, msg *types.MsgRegister
 
 	evmAddr := gethcommon.HexToAddress(msg.EvmAddress)
 
-	if _, exists := k.StakingKeeper.GetValidator(ctx, valAddr); !exists {
-		return nil, staking.ErrNoValidatorFound
+	if _, err = k.StakingKeeper.GetValidator(ctx, valAddr); err != nil {
+		return nil, err
 	}
 
 	if !k.IsEVMAddressUnique(ctx, evmAddr) {
-		return nil, errors.Wrapf(types.ErrEVMAddressAlreadyExists, "address %s", msg.EvmAddress)
+		return nil, sdkerrors.Wrapf(types.ErrEVMAddressAlreadyExists, "address %s", msg.EvmAddress)
 	}
 
 	k.SetEVMAddress(ctx, valAddr, evmAddr)

--- a/x/signal/interfaces.go
+++ b/x/signal/interfaces.go
@@ -1,13 +1,15 @@
 package signal
 
 import (
+	"context"
+
 	"cosmossdk.io/math"
 	stakingtypes "cosmossdk.io/x/staking/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type StakingKeeper interface {
-	GetLastValidatorPower(ctx sdk.Context, addr sdk.ValAddress) int64
-	GetLastTotalPower(ctx sdk.Context) math.Int
-	GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, found bool)
+	GetLastValidatorPower(ctx context.Context, addr sdk.ValAddress) (int64, error)
+	GetLastTotalPower(ctx context.Context) (math.Int, error)
+	GetValidator(ctx context.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, err error)
 }

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -1,6 +1,7 @@
 package signal_test
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/big"
@@ -492,22 +493,22 @@ func newMockStakingKeeper(validators map[string]int64) *mockStakingKeeper {
 	}
 }
 
-func (m *mockStakingKeeper) GetLastTotalPower(_ sdk.Context) sdkmath.Int {
-	return m.totalVotingPower
+func (m *mockStakingKeeper) GetLastTotalPower(_ context.Context) (sdkmath.Int, error) {
+	return m.totalVotingPower, nil
 }
 
-func (m *mockStakingKeeper) GetLastValidatorPower(_ sdk.Context, addr sdk.ValAddress) int64 {
+func (m *mockStakingKeeper) GetLastValidatorPower(_ context.Context, addr sdk.ValAddress) (int64, error) {
 	addrStr := addr.String()
 	if power, ok := m.validators[addrStr]; ok {
-		return power
+		return power, nil
 	}
-	return 0
+	return 0, nil
 }
 
-func (m *mockStakingKeeper) GetValidator(_ sdk.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, found bool) {
+func (m *mockStakingKeeper) GetValidator(_ context.Context, addr sdk.ValAddress) (validator stakingtypes.Validator, err error) {
 	addrStr := addr.String()
 	if _, ok := m.validators[addrStr]; ok {
-		return stakingtypes.Validator{Status: stakingtypes.Bonded}, true
+		return stakingtypes.Validator{Status: stakingtypes.Bonded}, nil
 	}
-	return stakingtypes.Validator{}, false
+	return stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound
 }


### PR DESCRIPTION
The module manager work with configurator and upgrades was a little tricky.

- Upgrade gov keeper
- ABCI methods in app.go
- Add `RegisterServices` to `Configurator`, satisfying 0.52 interface.  Include `acceptedMessages` logic.
- Update module manager to sync with 0.52 implementation, copy over code where appropriate.