### PR TITLE
chore: replace moduletestutil followup

### DIFF
--- a/app/benchmarks/benchmark_ibc_update_client_test.go
+++ b/app/benchmarks/benchmark_ibc_update_client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
@@ -22,7 +23,6 @@ import (
 	tmprotoversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	"github.com/cometbft/cometbft/version"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	types3 "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	types2 "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
 	types4 "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"

--- a/app/benchmarks/benchmark_msg_send_test.go
+++ b/app/benchmarks/benchmark_msg_send_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
@@ -17,7 +18,6 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/proto/tendermint/version"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
 )

--- a/app/benchmarks/benchmark_pfb_test.go
+++ b/app/benchmarks/benchmark_pfb_test.go
@@ -9,9 +9,9 @@ import (
 
 	"cosmossdk.io/log"
 	"github.com/cometbft/cometbft/crypto"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	tmcfg "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	icagenesistypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/genesis/types"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ import (
 // Test_newGovModule verifies that the gov module's genesis state has defaults
 // overridden.
 func Test_newGovModule(t *testing.T) {
-	enc := moduletestutil.MakeTestEncodingConfig(ModuleEncodingRegisters...)
+	enc := encoding.MakeTestConfig(ModuleEncodingRegisters...)
 	day := time.Hour * 24
 	oneWeek := day * 7
 
@@ -83,7 +83,7 @@ func TestDefaultConsensusConfig(t *testing.T) {
 }
 
 func Test_icaDefaultGenesis(t *testing.T) {
-	enc := moduletestutil.MakeTestEncodingConfig(ModuleEncodingRegisters...)
+	enc := encoding.MakeTestConfig(ModuleEncodingRegisters...)
 	ica := icaModule{}
 	raw := ica.DefaultGenesis(enc.Codec)
 	got := icagenesistypes.GenesisState{}

--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -9,6 +9,8 @@ import (
 
 	"cosmossdk.io/math"
 	tmrand "cosmossdk.io/math/unsafe"
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -16,7 +18,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
@@ -44,7 +45,7 @@ func QueryWithoutProof(clientCtx client.Context, hashHexStr string) (*rpctypes.R
 }
 
 func NewKeyring(accounts ...string) (keyring.Keyring, []sdk.AccAddress) {
-	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+	cdc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...).Codec
 	kb := keyring.NewInMemory(cdc)
 
 	addresses := make([]sdk.AccAddress, len(accounts))

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	tmrand "cosmossdk.io/math/unsafe"
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
@@ -15,7 +17,6 @@ import (
 	"github.com/celestiaorg/go-square/v2/share"
 	blobtx "github.com/celestiaorg/go-square/v2/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +35,7 @@ func TestBlobShareDecorator(t *testing.T) {
 	}
 
 	rand := tmrand.NewRand()
-	ecfg := moduletestutil.MakeTestEncodingConfig()
+	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 
 	testCases := []testCase{
 		{
@@ -135,7 +136,7 @@ func TestBlobShareDecorator(t *testing.T) {
 			kr, _ := testnode.NewKeyring(testfactory.TestAccName)
 			signer, err := user.NewSigner(
 				kr,
-				ecfg.TxConfig,
+				enc.TxConfig,
 				testfactory.ChainID,
 				tc.appVersion,
 				user.NewAccount(testfactory.TestAccName, 1, 0),
@@ -148,7 +149,7 @@ func TestBlobShareDecorator(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, isBlob)
 
-			sdkTx, err := ecfg.TxConfig.TxDecoder()(btx.Tx)
+			sdkTx, err := enc.TxConfig.TxDecoder()(btx.Tx)
 			require.NoError(t, err)
 
 			decorator := ante.NewBlobShareDecorator(mockBlobKeeper{})

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -3,13 +3,14 @@ package ante_test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	ante "github.com/celestiaorg/celestia-app/v4/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 	"github.com/celestiaorg/go-square/v2/share"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,7 +121,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 		},
 	}
 
-	txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txConfig := encoding.MakeTestConfig(app.ModuleEncodingRegisters...).TxConfig
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			txBuilder := txConfig.NewTxBuilder()

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -7,19 +7,17 @@ import (
 	"cosmossdk.io/math"
 	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
-	"github.com/celestiaorg/celestia-app/v4/x/blob"
 	"github.com/celestiaorg/celestia-app/v4/x/blob/types"
 	"github.com/celestiaorg/go-square/v2/inclusion"
 	"github.com/celestiaorg/go-square/v2/share"
 	"github.com/celestiaorg/go-square/v2/tx"
 	"github.com/cometbft/cometbft/crypto/merkle"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/bank"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +37,7 @@ func TestNewV0Blob(t *testing.T) {
 }
 
 func TestValidateBlobTx(t *testing.T) {
-	encCfg := moduletestutil.MakeTestEncodingConfig(bank.AppModuleBasic{}, blob.AppModule{})
+	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	signer, err := testnode.NewOfflineSigner()
 	require.NoError(t, err)
 	ns1 := share.MustNewV0Namespace(bytes.Repeat([]byte{0x01}, share.NamespaceVersionZeroIDSize))

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -8,6 +8,7 @@ import (
 
 	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
@@ -16,12 +17,11 @@ import (
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 	blobtx "github.com/celestiaorg/go-square/v2/tx"
 	abci "github.com/cometbft/cometbft/abci/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPFBGasEstimation(t *testing.T) {
-	encCfg := moduletestutil.MakeTestEncodingConfig()
+	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	rand := tmrand.NewRand()
 
 	testCases := []struct {
@@ -75,7 +75,7 @@ func FuzzPFBGasEstimation(f *testing.F) {
 		maxBlobSize = 418
 		seed        = int64(9001)
 	)
-	encCfg := moduletestutil.MakeTestEncodingConfig()
+	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	f.Add(numBlobs, maxBlobSize, seed)
 	f.Fuzz(func(t *testing.T, numBlobs, maxBlobSize int, seed int64) {
 		if numBlobs <= 0 || maxBlobSize <= 0 {

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -8,15 +8,16 @@ import (
 	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/x/mint/simulation"
 	"github.com/celestiaorg/celestia-app/v4/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+	cdc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...).Codec
 	decoder := simulation.NewDecodeStore(cdc)
 	minter := types.NewMinter(math.LegacyOneDec(), math.LegacyNewDec(15), sdk.DefaultBondDenom)
 	unixEpoch := time.Unix(0, 0).UTC()

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -12,6 +12,8 @@ import (
 	"cosmossdk.io/store"
 	"cosmossdk.io/store/metrics"
 	storetypes "cosmossdk.io/store/types"
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
@@ -22,7 +24,6 @@ import (
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	dbm "github.com/cosmos/cosmos-db"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,7 @@ func TestGetVotingPowerThreshold(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := moduletestutil.MakeTestEncodingConfig()
+			config := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 			stakingKeeper := newMockStakingKeeper(tc.validators)
 			k := signal.NewKeeper(config.Codec, nil, stakingKeeper)
 			got := k.GetVotingPowerThreshold(sdk.Context{})
@@ -476,7 +477,7 @@ func setup(t *testing.T) (signal.Keeper, sdk.Context, *mockStakingKeeper) {
 			testutil.ValAddrs[3].String(): 20,
 		},
 	)
-	config := moduletestutil.MakeTestEncodingConfig()
+	config := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	upgradeKeeper := signal.NewKeeper(config.Codec, signalStore, mockStakingKeeper)
 	return upgradeKeeper, mockCtx, mockStakingKeeper
 }

--- a/x/signal/legacy_test.go
+++ b/x/signal/legacy_test.go
@@ -10,6 +10,7 @@ import (
 	tmrand "cosmossdk.io/math/unsafe"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
@@ -17,7 +18,6 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/stretchr/testify/require"
@@ -48,7 +48,7 @@ type LegacyUpgradeTestSuite struct {
 
 	accounts []string
 	cctx     testnode.Context
-	ecfg     moduletestutil.TestEncodingConfig
+	ecfg     encoding.Config
 
 	govModuleAddress string
 
@@ -61,7 +61,7 @@ type LegacyUpgradeTestSuite struct {
 func (s *LegacyUpgradeTestSuite) SetupSuite() {
 	t := s.T()
 
-	s.ecfg = moduletestutil.MakeTestEncodingConfig()
+	s.ecfg = encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 
 	// we create an arbitrary number of funded accounts
 	accounts := make([]string, 3)


### PR DESCRIPTION
Replaces moduletestutil usage. 

Adds codec to `TxClient` in pkg user in order to access the `GetMsgV1Signers` api