### PR TITLE
chore: re-add logic to extract signature from message

### DIFF
--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -177,7 +177,7 @@ well funded account that can act as the master account. The command runs until a
 				opts.SuppressLogs()
 			}
 
-			encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+			encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 			err = txsim.Run(
 				cmd.Context(),
 				grpcEndpoint,

--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -1,6 +1,7 @@
 package txsim
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -203,6 +204,20 @@ func (am *AccountManager) Submit(ctx context.Context, op Operation) error {
 			if err := m.ValidateBasic(); err != nil {
 				return fmt.Errorf("error validating message: %w", err)
 			}
+		}
+		signers, _, err := am.encCfg.Codec.GetMsgV1Signers(msg)
+		if err != nil {
+			return fmt.Errorf("error getting signers for message: %w", err)
+		}
+
+		if len(signers) != 1 {
+			return fmt.Errorf("only a single signer is supported got: %d", len(signers))
+		}
+
+		if address == nil {
+			address = signers[0]
+		} else if !bytes.Equal(address, signers[0]) {
+			return fmt.Errorf("all messages must be signed by the same account")
 		}
 	}
 


### PR DESCRIPTION
There was code that used `msg.GetSigners()` previously that was accidentally removed from the 50 branch.