### PR TITLE
test: fix TestCircuitBreaker

### DIFF
--- a/app/test/circuit_breaker_test.go
+++ b/app/test/circuit_breaker_test.go
@@ -7,16 +7,10 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
-	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
-	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util"
-	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	signaltypes "github.com/celestiaorg/celestia-app/v4/x/signal/types"
-	abci "github.com/cometbft/cometbft/abci/types"
-	coretypes "github.com/cometbft/cometbft/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,11 +29,15 @@ var expiration = time.Now().Add(time.Hour)
 // message that contains a MsgTryUpgrade if the MsgTryUpgrade is not supported
 // in the current version.
 func TestCircuitBreaker(t *testing.T) { // TODO: we need to pass a find a way to update the app version easily
-	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
+
+	// NOTE: the below sections are commented out due to the lack of the MsgVersioningGateKeeper ante handler, this will not be required
+	// once the multiplexer is implemented.
+
+	//enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	testApp, keyRing := util.SetupTestAppWithGenesisValSet(app.DefaultInitialConsensusParams(), granter, grantee)
 	header := tmproto.Header{Time: time.Now(), Height: 2, Version: version.Consensus{App: appVersion}}
-	signer, err := user.NewSigner(keyRing, enc.TxConfig, util.ChainID, appVersion, user.NewAccount(granter, 2, 0))
-	require.NoError(t, err)
+	//signer, err := user.NewSigner(keyRing, enc.TxConfig, util.ChainID, appVersion, user.NewAccount(granter, 2, 0))
+	//require.NoError(t, err)
 
 	granterAddress := testfactory.GetAddress(keyRing, granter)
 	granteeAddress := testfactory.GetAddress(keyRing, grantee)
@@ -52,42 +50,45 @@ func TestCircuitBreaker(t *testing.T) { // TODO: we need to pass a find a way to
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "/celestia.signal.v1.Msg/TryUpgrade doesn't exist.: invalid type")
 
-	_, err = testApp.BeginBlocker(ctx)
-	require.NoError(t, err)
+	// when the muiliplexer is introduced.
 
-	tryUpgradeTx := newTryUpgradeTx(t, signer, granterAddress)
-	blockResp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{Txs: [][]byte{tryUpgradeTx}, Height: 2, Time: ctx.BlockTime()})
-	require.NoError(t, err)
-	res := blockResp.TxResults[0]
-	assert.Equal(t, uint32(0x25), res.Code, res.Log)
-	assert.Contains(t, res.Log, "message type /celestia.signal.v1.MsgTryUpgrade is not supported in version 1: feature not supported")
-
-	nestedTx := newNestedTx(t, signer, granterAddress)
-	blockResp, err = testApp.FinalizeBlock(&abci.RequestFinalizeBlock{Txs: [][]byte{nestedTx}})
-	require.NoError(t, err)
-	res = blockResp.TxResults[0]
-	assert.Equal(t, uint32(0x25), res.Code, res.Log)
-	assert.Contains(t, res.Log, "message type /celestia.signal.v1.MsgTryUpgrade is not supported in version 1: feature not supported")
+	//_, err = testApp.BeginBlocker(ctx)
+	//require.NoError(t, err)
+	//
+	//tryUpgradeTx := newTryUpgradeTx(t, signer, granterAddress)
+	//blockResp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{Txs: [][]byte{tryUpgradeTx}, Height: 2, Time: ctx.BlockTime()})
+	//require.NoError(t, err)
+	//res := blockResp.TxResults[0]
+	//assert.Equal(t, uint32(0x25), res.Code, res.Log)
+	//assert.Contains(t, res.Log, "message type /celestia.signal.v1.MsgTryUpgrade is not supported in version 1: feature not supported")
+	//
+	//nestedTx := newNestedTx(t, signer, granterAddress)
+	//blockResp, err = testApp.FinalizeBlock(&abci.RequestFinalizeBlock{Txs: [][]byte{nestedTx}})
+	//require.NoError(t, err)
+	//res = blockResp.TxResults[0]
+	//assert.Equal(t, uint32(0x25), res.Code, res.Log)
+	//assert.Contains(t, res.Log, "message type /celestia.signal.v1.MsgTryUpgrade is not supported in version 1: feature not supported")
 }
 
-func newTryUpgradeTx(t *testing.T, signer *user.Signer, senderAddress sdk.AccAddress) coretypes.Tx {
-	msg := signaltypes.NewMsgTryUpgrade(senderAddress)
-	options := blobfactory.FeeTxOpts(1e9)
-
-	rawTx, _, err := signer.CreateTx([]sdk.Msg{msg}, options...)
-	require.NoError(t, err)
-
-	return rawTx
-}
-
-func newNestedTx(t *testing.T, signer *user.Signer, granterAddress sdk.AccAddress) coretypes.Tx {
-	innerMsg := signaltypes.NewMsgTryUpgrade(granterAddress)
-	msg := authz.NewMsgExec(granterAddress, []sdk.Msg{innerMsg})
-
-	options := blobfactory.FeeTxOpts(1e9)
-
-	rawTx, _, err := signer.CreateTx([]sdk.Msg{&msg}, options...)
-	require.NoError(t, err)
-
-	return rawTx
-}
+//
+//func newTryUpgradeTx(t *testing.T, signer *user.Signer, senderAddress sdk.AccAddress) coretypes.Tx {
+//	msg := signaltypes.NewMsgTryUpgrade(senderAddress)
+//	options := blobfactory.FeeTxOpts(1e9)
+//
+//	rawTx, _, err := signer.CreateTx([]sdk.Msg{msg}, options...)
+//	require.NoError(t, err)
+//
+//	return rawTx
+//}
+//
+//func newNestedTx(t *testing.T, signer *user.Signer, granterAddress sdk.AccAddress) coretypes.Tx {
+//	innerMsg := signaltypes.NewMsgTryUpgrade(granterAddress)
+//	msg := authz.NewMsgExec(granterAddress, []sdk.Msg{innerMsg})
+//
+//	options := blobfactory.FeeTxOpts(1e9)
+//
+//	rawTx, _, err := signer.CreateTx([]sdk.Msg{&msg}, options...)
+//	require.NoError(t, err)
+//
+//	return rawTx
+//}


### PR DESCRIPTION
The circuit breaker test depends on an ante handler that was removed, and whose functionality will be replaced by the multi plexer. 

Leaving code commented out for transparency, if there is a preference we can delete it instead. 