### PR TITLE
chore: remove test that expects special casing on the ante handler

### DIFF
--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -6,7 +6,6 @@ import (
 	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
@@ -38,12 +37,6 @@ func TestBlobShareDecorator(t *testing.T) {
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 
 	testCases := []testCase{
-		{
-			name:        "want no error if appVersion v1 and 8 MiB blob",
-			blobsPerPFB: 1,
-			blobSize:    8 * mebibyte,
-			appVersion:  v1.Version,
-		},
 		{
 			name:        "PFB with 1 blob that is 1 byte",
 			blobsPerPFB: 1,


### PR DESCRIPTION
The `BlobShareDecorator` used to special case v1 and perform a no-op, this logic is removed, so this test no longer makes sense to have.