### PR TITLE
chore: get tx client test passing

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -43,7 +43,7 @@ type TxClientTestSuite struct {
 	serviceClient sdktx.ServiceClient
 }
 
-func (suite *TxClientTestSuite) SetupSuite() {
+func (suite *TxClientTestSuite) SetupTest() {
 	suite.encCfg, suite.txClient, suite.ctx = setupTxClient(suite.T())
 	suite.serviceClient = sdktx.NewServiceClient(suite.ctx.GRPCClient)
 }
@@ -322,6 +322,7 @@ func setupTxClient(t *testing.T) (encoding.Config, *user.TxClient, testnode.Cont
 		WithTendermintConfig(defaultTmConfig).
 		WithFundedAccounts("a", "b", "c").
 		WithChainID(chainID).
+		WithTimeoutCommit(100 * time.Millisecond).
 		WithAppCreator(testnode.CustomAppCreator(baseapp.SetMinGasPrices("0utia"), baseapp.SetChainID(chainID)))
 
 	ctx, _, _ := testnode.NewNetwork(t, testnodeConfig)

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -188,7 +188,7 @@ func DefaultAppCreator(opts ...AppCreationOptions) srvtypes.AppCreator {
 // Returns a function that initializes the app.
 func CustomAppCreator(appOptions ...func(*baseapp.BaseApp)) srvtypes.AppCreator {
 	return func(log.Logger, dbm.DB, io.Writer, srvtypes.AppOptions) srvtypes.Application {
-		app := app.New(
+		return app.New(
 			log.NewNopLogger(),
 			dbm.NewMemDB(),
 			nil, // trace store
@@ -196,7 +196,6 @@ func CustomAppCreator(appOptions ...func(*baseapp.BaseApp)) srvtypes.AppCreator 
 			simtestutil.EmptyAppOptions{},
 			appOptions...,
 		)
-		return app
 	}
 }
 


### PR DESCRIPTION
This one is super strange, it looks like unless the node/txClient is re-created for each test, there is some indeterminacy. This is definitely a bug somewhere and will create an issue to track it, but for now we can make these changes and debug further once the rest of the tests are green. 


[CEL-46](https://linear.app/binarybuilders/issue/CEL-46/look-into-setupsuite-setuptest-in-testtxclienttestsuite)