### PR TITLE
test: fixing TestMaliciousTestNode / TestInitChainer / TestGenerateManyRandomRawSendTxsSameSigner_Deterministic

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"encoding/json"
+	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,11 +65,11 @@ func TestInitChain(t *testing.T) {
 	traceStore := &NoopWriter{}
 	timeoutCommit := time.Second
 	appOptions := NoopAppOptions{}
-	testApp := app.New(logger, db, traceStore, timeoutCommit, appOptions)
+	testApp := app.New(logger, db, traceStore, timeoutCommit, appOptions, baseapp.SetChainID(testfactory.ChainID))
 	genesisState, _, _ := util.GenesisStateWithSingleValidator(testApp, "account")
 	appStateBytes, err := json.MarshalIndent(genesisState, "", " ")
 	require.NoError(t, err)
-	genesis := testnode.DefaultConfig().Genesis
+	genesis := testnode.DefaultConfig().Genesis.WithChainID(testApp.ChainID())
 
 	type testCase struct {
 		name      string
@@ -102,7 +103,7 @@ func TestInitChain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			application := app.New(logger, db, traceStore, timeoutCommit, appOptions)
+			application := app.New(logger, db, traceStore, timeoutCommit, appOptions, baseapp.SetChainID(testfactory.ChainID))
 			if tc.wantPanic {
 				_, err := application.InitChain(&tc.request)
 				assert.Error(t, err)

--- a/test/util/blobfactory/test_util.go
+++ b/test/util/blobfactory/test_util.go
@@ -58,9 +58,6 @@ func GenerateRawSendTx(signer *user.Signer, amount int64) []byte {
 
 // GenerateRandomAmount generates a random amount for a Send transaction.
 func GenerateRandomAmount(r *rand.Rand) int64 {
-	if r == nil {
-		r = rand.New(rand.NewSource(1))
-	}
 	n := r.Int63()
 	if n < 0 {
 		return -n

--- a/test/util/blobfactory/test_util.go
+++ b/test/util/blobfactory/test_util.go
@@ -1,7 +1,7 @@
 package blobfactory
 
 import (
-	"math/rand/v2"
+	"math/rand"
 
 	"cosmossdk.io/math"
 	coretypes "github.com/cometbft/cometbft/types"
@@ -57,8 +57,11 @@ func GenerateRawSendTx(signer *user.Signer, amount int64) []byte {
 }
 
 // GenerateRandomAmount generates a random amount for a Send transaction.
-func GenerateRandomAmount() int64 {
-	n := rand.Int64()
+func GenerateRandomAmount(r *rand.Rand) int64 {
+	if r == nil {
+		r = rand.New(rand.NewSource(1))
+	}
+	n := r.Int63()
 	if n < 0 {
 		return -n
 	}
@@ -66,16 +69,16 @@ func GenerateRandomAmount() int64 {
 }
 
 // GenerateRandomRawSendTx generates a random raw send tx.
-func GenerateRandomRawSendTx(signer *user.Signer) (rawTx []byte) {
-	amount := GenerateRandomAmount()
+func GenerateRandomRawSendTx(rand *rand.Rand, signer *user.Signer) (rawTx []byte) {
+	amount := GenerateRandomAmount(rand)
 	return GenerateRawSendTx(signer, amount)
 }
 
 // GenerateManyRandomRawSendTxsSameSigner  generates count many random raw send txs.
-func GenerateManyRandomRawSendTxsSameSigner(signer *user.Signer, count int) []coretypes.Tx {
+func GenerateManyRandomRawSendTxsSameSigner(rand *rand.Rand, signer *user.Signer, count int) []coretypes.Tx {
 	txs := make([]coretypes.Tx, count)
 	for i := 0; i < count; i++ {
-		txs[i] = GenerateRandomRawSendTx(signer)
+		txs[i] = GenerateRandomRawSendTx(rand, signer)
 	}
 	return txs
 }

--- a/test/util/blobfactory/test_util_test.go
+++ b/test/util/blobfactory/test_util_test.go
@@ -1,6 +1,7 @@
 package blobfactory_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,7 @@ import (
 // TestGenerateManyRandomRawSendTxsSameSigner_Deterministic tests whether with the same random seed the GenerateManyRandomRawSendTxsSameSigner function produces the same send transactions.
 func TestGenerateManyRandomRawSendTxsSameSigner_Deterministic(t *testing.T) {
 	normalTxCount := 10
+	seed := int64(1)
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	TxDecoder := enc.TxConfig.TxDecoder()
 
@@ -25,10 +27,10 @@ func TestGenerateManyRandomRawSendTxsSameSigner_Deterministic(t *testing.T) {
 	signer, err := user.NewSigner(kr, enc.TxConfig, testfactory.ChainID, appconsts.LatestVersion, user.NewAccount(testfactory.TestAccName, 1, 0))
 	require.NoError(t, err)
 
-	encodedTxs1 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(signer, normalTxCount)
+	encodedTxs1 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(rand.New(rand.NewSource(seed)), signer, normalTxCount)
 
 	require.NoError(t, signer.SetSequence(testfactory.TestAccName, 0))
-	encodedTxs2 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(signer, normalTxCount)
+	encodedTxs2 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(rand.New(rand.NewSource(seed)), signer, normalTxCount)
 
 	// additional check for the sake of future debugging
 	for i := 0; i < normalTxCount; i++ {

--- a/test/util/malicious/app.go
+++ b/test/util/malicious/app.go
@@ -1,13 +1,12 @@
 package malicious
 
 import (
-	"io"
-
 	"cosmossdk.io/log"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"io"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 )

--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -118,5 +118,5 @@ func TestMaliciousTestNode(t *testing.T) {
 
 	goodDah, err := da.NewDataAvailabilityHeader(goodEds)
 	require.NoError(t, err)
-	require.NotEqual(t, block.Block.DataHash.Bytes(), goodDah.Hash())
+	require.NotEqual(t, block.Block.DataRootHash.Bytes(), goodDah.Hash())
 }

--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -1,12 +1,12 @@
 package malicious
 
 import (
-	"math/rand"
-	"testing"
-
 	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
 
 	square "github.com/celestiaorg/go-square/v2"
 	"github.com/celestiaorg/go-square/v2/share"
@@ -72,7 +72,8 @@ func TestMaliciousTestNode(t *testing.T) {
 	}
 	accounts := testfactory.RandomAccountNames(5)
 	cfg := OutOfOrderNamespaceConfig(5).
-		WithFundedAccounts(accounts...)
+		WithFundedAccounts(accounts...).
+		WithTimeoutCommit(100 * time.Millisecond)
 
 	cctx, _, _ := testnode.NewNetwork(t, cfg)
 	_, err := cctx.WaitForHeight(6)
@@ -104,7 +105,7 @@ func TestMaliciousTestNode(t *testing.T) {
 
 	dah, err := da.NewDataAvailabilityHeader(eds)
 	require.NoError(t, err)
-	require.Equal(t, block.Block.DataHash.Bytes(), dah.Hash())
+	require.Equal(t, block.Block.DataRootHash.Bytes(), dah.Hash())
 
 	correctSquare, err := square.Construct(block.Block.Txs.ToSliceOfBytes(),
 		appconsts.DefaultSquareSizeUpperBound,

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -1,6 +1,7 @@
 package malicious
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	abci "github.com/cometbft/cometbft/abci/types"
 	core "github.com/cometbft/cometbft/proto/tendermint/types"
 	version "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -18,19 +19,14 @@ import (
 // for. It will swap the order of two blobs in the square and then use the
 // modified nmt to create a commitment over the modified square.
 func (a *App) OutOfOrderPrepareProposal(req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
-	ctx := a.NewContext(false)
-	appVersion, err := a.AppVersion(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// create a context using a branch of the state and loaded using the
 	// proposal height and chain-id
 	sdkCtx := a.NewProposalContext(core.Header{
-		Height: req.Height,
-		Time:   req.Time,
+		ChainID: a.ChainID(),
+		Height:  req.Height,
+		Time:    req.Time,
 		Version: version.Consensus{
-			App: appVersion,
+			App: appconsts.LatestVersion,
 		},
 	})
 	// filter out invalid transactions.
@@ -54,7 +50,7 @@ func (a *App) OutOfOrderPrepareProposal(req *abci.RequestPrepareProposal) (*abci
 
 	// build the square from the set of valid and prioritised transactions.
 	// The txs returned are the ones used in the square and block
-	dataSquare, txs, err := Build(txs, appVersion, a.MaxEffectiveSquareSize(sdkCtx), OutOfOrderExport)
+	dataSquare, txs, err := Build(txs, appconsts.LatestVersion, a.MaxEffectiveSquareSize(sdkCtx), OutOfOrderExport)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- WithTimeoutCommit(100 * time.Millisecond) needed to be set like in other tests.
- Hard code usage of app version to latest.
- correctly pass chainID to header.
- Modify assertion to check against `DataRootHash` 
- Fix init chainer test by making sure chain IDs align
- Re-enable the functionality to pass in a rand struct to ensure the same seed is used for the deterministic tests.