### PR TITLE
fix: added random package to acommodate removal of functionality from tmrand

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"encoding/json"
-	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/test/util"
+	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v4/x/minfee"
 )

--- a/app/export.go
+++ b/app/export.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	storetypes "cosmossdk.io/store/types"
-
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -17,7 +16,7 @@ import (
 // ExportAppStateAndValidators exports the state of the application for a genesis
 // file.
 func (app *App) ExportAppStateAndValidators(
-	forZeroHeight bool, jailAllowedAddrs []string, modulesToExport []string,
+	forZeroHeight bool, jailAllowedAddrs []string, _ []string,
 ) (servertypes.ExportedApp, error) {
 	// as if they could withdraw from the start of the next block
 	ctx := app.NewContext(true)

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"bytes"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -23,6 +22,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -2,9 +2,9 @@ package app_test
 
 import (
 	"bytes"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -125,7 +125,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[4]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[4]).Address().String(), 10_000, 10)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[4]).Address().String(), 10_000, 10)
 				tx, _, err := signer.CreatePayForBlobs(accs[4], blobs, opts...)
 				require.NoError(t, err)
 				return tx
@@ -137,7 +137,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[5]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[5]).Address().String(), 1_000, 1)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[5]).Address().String(), 1_000, 1)
 				tx, _, err := signer.CreatePayForBlobs(accs[5], blobs, opts...)
 				require.NoError(t, err)
 				return tx
@@ -149,7 +149,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[6]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[6]).Address().String(), 10_000, 1)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[6]).Address().String(), 10_000, 1)
 				tx, _, err := signer.CreatePayForBlobs(accs[6], blobs, opts...)
 				require.NoError(t, err)
 				return tx
@@ -161,7 +161,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[7]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[7]).Address().String(), 100_000, 1)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[7]).Address().String(), 100_000, 1)
 				tx, _, err := signer.CreatePayForBlobs(accs[7], blobs, opts...)
 				require.NoError(t, err)
 				return tx
@@ -173,7 +173,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[8]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[8]).Address().String(), 1_000_000, 1)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[8]).Address().String(), 1_000_000, 1)
 				tx, _, err := signer.CreatePayForBlobs(accs[8], blobs, opts...)
 				require.NoError(t, err)
 				return tx
@@ -185,7 +185,7 @@ func TestCheckTx(t *testing.T) {
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				signer := signers[9]
-				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), signer.Account(accs[9]).Address().String(), 2_000_000, 1)
+				_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), signer.Account(accs[9]).Address().String(), 2_000_000, 1)
 				tx, _, err := signer.CreatePayForBlobs(accs[9], blobs, opts...)
 				require.NoError(t, err)
 				return tx

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 )
 
 // TestPrepareProposalConsistency produces blocks with random data using

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -1,10 +1,10 @@
 package app_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
@@ -31,7 +31,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	accounts := make([]string, 1100) // 1000 for creating blob txs, 100 for creating send txs
 	for i := range accounts {
-		accounts[i] = tmrand.Str(20)
+		accounts[i] = random.Str(20)
 	}
 	maxShareCount := int64(appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound)
 

--- a/app/test/gas_estimation_test.go
+++ b/app/test/gas_estimation_test.go
@@ -2,12 +2,12 @@ package app
 
 import (
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -61,7 +61,7 @@ func TestEstimateGasPrice(t *testing.T) {
 			defer wg.Done()
 			// ensure that it is greater than the min gas price
 			gasPrice := float64(rand.Intn(1000)+1) * appconsts.DefaultMinGasPrice
-			blobs := blobfactory.ManyBlobs(tmrand.NewRand(), []share.Namespace{share.RandomBlobNamespace()}, []int{100})
+			blobs := blobfactory.ManyBlobs(random.New(), []share.Namespace{share.RandomBlobNamespace()}, []int{100})
 			resp, err := txClient.BroadcastPayForBlobWithAccount(
 				cctx.GoContext(),
 				accName,
@@ -170,7 +170,7 @@ func TestEstimateGasUsed(t *testing.T) {
 
 	// create a PFB
 	blobSize := 100
-	blobs := blobfactory.ManyRandBlobs(tmrand.NewRand(), blobSize)
+	blobs := blobfactory.ManyRandBlobs(random.New(), blobSize)
 	pfbTx, _, err := txClient.Signer().CreatePayForBlobs(
 		"test",
 		blobs,

--- a/app/test/gas_estimation_test.go
+++ b/app/test/gas_estimation_test.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"sync"
 	"testing"
@@ -22,6 +21,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"os"
 	"testing"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/da"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"os"
 	"testing"
 
@@ -72,7 +73,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 	singleBlobTxGen := func(c client.Context) []coretypes.Tx {
 		return blobfactory.RandBlobTxsWithAccounts(
 			s.ecfg,
-			tmrand.NewRand(),
+			random.New(),
 			s.cctx.Keyring,
 			c.GRPCClient,
 			600*kibibyte,
@@ -87,7 +88,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 	multiBlobTxGen := func(c client.Context) []coretypes.Tx {
 		return blobfactory.RandBlobTxsWithAccounts(
 			s.ecfg,
-			tmrand.NewRand(),
+			random.New(),
 			s.cctx.Keyring,
 			c.GRPCClient,
 			200*kibibyte,
@@ -100,7 +101,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 	randomTxGen := func(c client.Context) []coretypes.Tx {
 		return blobfactory.RandBlobTxsWithAccounts(
 			s.ecfg,
-			tmrand.NewRand(),
+			random.New(),
 			s.cctx.Keyring,
 			c.GRPCClient,
 			50*kibibyte,
@@ -183,7 +184,7 @@ func (s *IntegrationTestSuite) TestUnwrappedPFBRejection() {
 
 	blobTx := blobfactory.RandBlobTxsWithAccounts(
 		s.ecfg,
-		tmrand.NewRand(),
+		random.New(),
 		s.cctx.Keyring,
 		s.cctx.GRPCClient,
 		int(100000),
@@ -205,7 +206,7 @@ func (s *IntegrationTestSuite) TestShareInclusionProof() {
 
 	txs := blobfactory.RandBlobTxsWithAccounts(
 		s.ecfg,
-		tmrand.NewRand(),
+		random.New(),
 		s.cctx.Keyring,
 		s.cctx.GRPCClient,
 		100*kibibyte,

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	coretypes "github.com/cometbft/cometbft/types"
@@ -273,7 +272,7 @@ func ExtendBlockTest(t *testing.T, block *coretypes.Block) {
 		// save block to json file for further debugging if this occurs
 		b, err := json.MarshalIndent(block, "", "  ")
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(fmt.Sprintf("bad_block_%s.json", tmrand.Str(6)), b, 0o644))
+		require.NoError(t, os.WriteFile(fmt.Sprintf("bad_block_%s.json", random.Str(6)), b, 0o644))
 	}
 }
 
@@ -301,7 +300,7 @@ func (s *IntegrationTestSuite) TestIsEmptyBlockRef() {
 
 func newBlobWithSize(size int) *share.Blob {
 	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
-	data := tmrand.Bytes(size)
+	data := random.Bytes(size)
 	blob, err := share.NewBlob(ns, data, share.ShareVersionZero, nil)
 	if err != nil {
 		panic(err)

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"crypto/rand"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"crypto/rand"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"testing"
 	"time"
@@ -99,7 +100,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 		infos[:3],
 		blobfactory.NestedBlobs(
 			t,
-			testfactory.RandomBlobNamespaces(tmrand.NewRand(), 3),
+			testfactory.RandomBlobNamespaces(random.New(), 3),
 			[][]int{{100}, {1000}, {420}},
 		),
 	)

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -155,7 +154,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 		infos[3:4],
 		blobfactory.NestedBlobs(
 			t,
-			testfactory.RandomBlobNamespaces(tmrand.NewRand(), 4000),
+			testfactory.RandomBlobNamespaces(random.New(), 4000),
 			[][]int{repeat(4000, 1)},
 		),
 	)[0]

--- a/app/test/priority_test.go
+++ b/app/test/priority_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +41,7 @@ type PriorityTestSuite struct {
 	txClient     *user.TxClient
 	cctx         testnode.Context
 
-	rand *tmrand.Rand
+	rand *rand.Rand
 }
 
 func (s *PriorityTestSuite) SetupSuite() {

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -3,7 +3,6 @@ package app_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"bytes"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func TestProcessProposal(t *testing.T) {
 		t, enc.TxConfig, kr, testutil.ChainID, accounts[:4], infos[:4],
 		blobfactory.NestedBlobs(
 			t,
-			testfactory.RandomBlobNamespaces(tmrand.NewRand(), 4),
+			testfactory.RandomBlobNamespaces(random.New(), 4),
 			[][]int{{100}, {1000}, {420}, {300}},
 		),
 	)
@@ -90,7 +91,7 @@ func TestProcessProposal(t *testing.T) {
 		infos[3:4],
 		blobfactory.NestedBlobs(
 			t,
-			testfactory.RandomBlobNamespaces(tmrand.NewRand(), 4000),
+			testfactory.RandomBlobNamespaces(random.New(), 4000),
 			[][]int{repeat(4000, 1)},
 		),
 	)[0]
@@ -164,7 +165,7 @@ func TestProcessProposal(t *testing.T) {
 			input: validData(),
 			mutator: func(d *tmproto.Data) {
 				index := 4
-				transaction, b := blobfactory.IndexWrappedTxWithInvalidNamespace(t, tmrand.NewRand(), signer, uint32(index))
+				transaction, b := blobfactory.IndexWrappedTxWithInvalidNamespace(t, random.New(), signer, uint32(index))
 				blobTx, err := tx.MarshalBlobTx(transaction, b)
 				require.NoError(t, err)
 

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	coretypes "github.com/cometbft/cometbft/types"
@@ -202,7 +201,7 @@ func TestProcessProposal(t *testing.T) {
 			name:  "undecodable tx with app version 1",
 			input: validData(),
 			mutator: func(d *tmproto.Data) {
-				d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
+				d.Txs = append([][]byte{random.Bytes(300)}, d.Txs...)
 				// Update the data hash so that the test doesn't fail due to an incorrect data root.
 				d.Hash = calculateNewDataHash(t, d.Txs)
 			},
@@ -213,7 +212,7 @@ func TestProcessProposal(t *testing.T) {
 			name:  "undecodable tx with app version 2",
 			input: validData(),
 			mutator: func(d *tmproto.Data) {
-				d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
+				d.Txs = append([][]byte{random.Bytes(300)}, d.Txs...)
 				// Update the data hash so that the test doesn't fail due to an incorrect data root.
 				d.Hash = calculateNewDataHash(t, d.Txs)
 			},

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v4/x/minfee"

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -1,12 +1,12 @@
 package app_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sync"
 	"testing"
 	"time"
 
 	"cosmossdk.io/math"
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -65,7 +65,7 @@ func (s *StandardSDKIntegrationTestSuite) SetupSuite() {
 
 	accounts := make([]string, 35)
 	for i := 0; i < len(accounts); i++ {
-		accounts[i] = tmrand.Str(9)
+		accounts[i] = random.Str(9)
 	}
 
 	s.cfg = testnode.DefaultConfig().WithFundedAccounts(accounts...)

--- a/pkg/inclusion/nmt_caching_test.go
+++ b/pkg/inclusion/nmt_caching_test.go
@@ -2,7 +2,6 @@ package inclusion
 
 import (
 	"bytes"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sort"
 	"testing"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/da"
 	"github.com/celestiaorg/celestia-app/v4/pkg/wrapper"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 )
 
 func TestWalkCachedSubTreeRoot(t *testing.T) {

--- a/pkg/inclusion/nmt_caching_test.go
+++ b/pkg/inclusion/nmt_caching_test.go
@@ -2,10 +2,10 @@ package inclusion
 
 import (
 	"bytes"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sort"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -192,7 +192,7 @@ func chunkSlice(slice [][]byte, chunkSize int) [][][]byte {
 // namespace.
 func generateRandNamespacedRawData(count int) (result [][]byte) {
 	for i := 0; i < count; i++ {
-		rawData := tmrand.Bytes(share.ShareSize)
+		rawData := random.Bytes(share.ShareSize)
 		namespace := share.RandomBlobNamespace().Bytes()
 		copy(rawData, namespace)
 		result = append(result, rawData)

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -2,7 +2,6 @@ package proof_test
 
 import (
 	"bytes"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"testing"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/da"
 	"github.com/celestiaorg/celestia-app/v4/pkg/proof"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -2,10 +2,10 @@ package proof_test
 
 import (
 	"bytes"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestNewTxInclusionProof(t *testing.T) {
 	signer, err := testnode.NewOfflineSigner()
 	require.NoError(t, err)
 
-	blockTxs = append(blockTxs, blobfactory.RandBlobTxs(signer, tmrand.NewRand(), 50, 1, 500).ToSliceOfBytes()...)
+	blockTxs = append(blockTxs, blobfactory.RandBlobTxs(signer, random.New(), 50, 1, 500).ToSliceOfBytes()...)
 	require.Len(t, blockTxs, 100)
 
 	type test struct {

--- a/pkg/user/e2e_test.go
+++ b/pkg/user/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )
 

--- a/pkg/user/e2e_test.go
+++ b/pkg/user/e2e_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sync"
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/cometbft/cometbft/config"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +43,7 @@ func TestConcurrentTxSubmission(t *testing.T) {
 
 			// Pregenerate all the blobs
 			numTxs := 100
-			blobs := blobfactory.ManyRandBlobs(tmrand.NewRand(), blobfactory.Repeat(2048, numTxs)...)
+			blobs := blobfactory.ManyRandBlobs(random.New(), blobfactory.Repeat(2048, numTxs)...)
 
 			// Prepare transactions
 			var (

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -2,7 +2,6 @@ package user_test
 
 import (
 	"context"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )
 

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -2,6 +2,7 @@ package user_test
 
 import (
 	"context"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func (suite *TxClientTestSuite) SetupTest() {
 
 func (suite *TxClientTestSuite) TestSubmitPayForBlob() {
 	t := suite.T()
-	blobs := blobfactory.ManyRandBlobs(unsafe.NewRand(), 1e3, 1e4)
+	blobs := blobfactory.ManyRandBlobs(random.New(), 1e3, 1e4)
 
 	subCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -3,7 +3,6 @@ package blobfactory
 import (
 	"bytes"
 	"context"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"testing"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -35,7 +34,7 @@ var (
 func RandMsgPayForBlobsWithSigner(rand *rand.Rand, signer string, size, blobCount int) (*blobtypes.MsgPayForBlobs, []*share.Blob) {
 	blobs := make([]*share.Blob, blobCount)
 	for i := 0; i < blobCount; i++ {
-		blob, err := blobtypes.NewV0Blob(testfactory.RandomBlobNamespaceWithPRG(rand), tmrand.Bytes(size))
+		blob, err := blobtypes.NewV0Blob(testfactory.RandomBlobNamespaceWithPRG(rand), random.Bytes(size))
 		if err != nil {
 			panic(err)
 		}
@@ -53,7 +52,7 @@ func RandV0BlobsWithNamespace(namespaces []share.Namespace, sizes []int) []*shar
 	blobs := make([]*share.Blob, len(namespaces))
 	var err error
 	for i, ns := range namespaces {
-		blobs[i], err = share.NewV0Blob(ns, tmrand.Bytes(sizes[i]))
+		blobs[i], err = share.NewV0Blob(ns, random.Bytes(sizes[i]))
 		if err != nil {
 			panic(err)
 		}
@@ -65,7 +64,7 @@ func RandV1BlobsWithNamespace(namespaces []share.Namespace, sizes []int, signer 
 	blobs := make([]*share.Blob, len(namespaces))
 	var err error
 	for i, ns := range namespaces {
-		blobs[i], err = share.NewV1Blob(ns, tmrand.Bytes(sizes[i]), signer)
+		blobs[i], err = share.NewV1Blob(ns, random.Bytes(sizes[i]), signer)
 		if err != nil {
 			panic(err)
 		}
@@ -74,7 +73,7 @@ func RandV1BlobsWithNamespace(namespaces []share.Namespace, sizes []int, signer 
 }
 
 func RandMsgPayForBlobsWithNamespaceAndSigner(signer string, ns share.Namespace, size int) (*blobtypes.MsgPayForBlobs, *share.Blob) {
-	blob, err := blobtypes.NewV0Blob(ns, tmrand.Bytes(size))
+	blob, err := blobtypes.NewV0Blob(ns, random.Bytes(size))
 	if err != nil {
 		panic(err)
 	}
@@ -90,7 +89,7 @@ func RandMsgPayForBlobsWithNamespaceAndSigner(signer string, ns share.Namespace,
 }
 
 func RandMsgPayForBlobs(rand *rand.Rand, size int) (*blobtypes.MsgPayForBlobs, *share.Blob) {
-	blob, err := share.NewBlob(testfactory.RandomBlobNamespaceWithPRG(rand), tmrand.Bytes(size), share.ShareVersionZero, nil)
+	blob, err := share.NewBlob(testfactory.RandomBlobNamespaceWithPRG(rand), random.Bytes(size), share.ShareVersionZero, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -218,7 +217,7 @@ func Repeat[T any](s T, count int) []T {
 func ManyBlobs(r *rand.Rand, namespaces []share.Namespace, sizes []int) []*share.Blob {
 	blobs := make([]*share.Blob, len(namespaces))
 	for i, ns := range namespaces {
-		blob, err := share.NewBlob(ns, random.Bytes(r, sizes[i]), share.ShareVersionZero, nil)
+		blob, err := share.NewBlob(ns, random.BytesR(r, sizes[i]), share.ShareVersionZero, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -232,7 +231,7 @@ func NestedBlobs(t *testing.T, namespaces []share.Namespace, sizes [][]int) [][]
 	counter := 0
 	for i, set := range sizes {
 		for _, size := range set {
-			blob, err := blobtypes.NewV0Blob(namespaces[counter], tmrand.Bytes(size))
+			blob, err := blobtypes.NewV0Blob(namespaces[counter], random.Bytes(size))
 			require.NoError(t, err)
 			blobs[i] = append(blobs[i], blob)
 			counter++

--- a/test/util/blobfactory/payforblob_factory_test.go
+++ b/test/util/blobfactory/payforblob_factory_test.go
@@ -1,9 +1,9 @@
 package blobfactory_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,12 +23,12 @@ func TestRandMultiBlobTxsSameSigner_Deterministic(t *testing.T) {
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	decoder := enc.TxConfig.TxDecoder()
 
-	rand1 := tmrand.NewRand()
+	rand1 := random.New()
 	rand1.Seed(1)
 	marshalledBlobTxs1 := blobfactory.RandMultiBlobTxsSameSigner(t, rand1, signer, pfbCount)
 
 	require.NoError(t, signer.SetSequence(testfactory.TestAccName, 0))
-	rand2 := tmrand.NewRand()
+	rand2 := random.New()
 	rand2.Seed(1)
 	marshalledBlobTxs2 := blobfactory.RandMultiBlobTxsSameSigner(t, rand2, signer, pfbCount)
 

--- a/test/util/blobfactory/payforblob_factory_test.go
+++ b/test/util/blobfactory/payforblob_factory_test.go
@@ -1,7 +1,6 @@
 package blobfactory_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	"github.com/cometbft/cometbft/types"
@@ -11,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )

--- a/test/util/direct_tx_gen.go
+++ b/test/util/direct_tx_gen.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"testing"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 )
 

--- a/test/util/direct_tx_gen.go
+++ b/test/util/direct_tx_gen.go
@@ -1,11 +1,11 @@
 package util
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"testing"
 
 	"cosmossdk.io/math"
-	tmrand "cosmossdk.io/math/unsafe"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -70,7 +70,7 @@ func RandBlobTxsWithAccounts(
 			}
 		}
 
-		_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), addr.String(), randomizedSize, randomizedBlobCount)
+		_, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), addr.String(), randomizedSize, randomizedBlobCount)
 		tx, _, err := signer.CreatePayForBlobs(account.Name(), blobs, opts...)
 		require.NoError(t, err)
 		txs[i] = tx
@@ -127,7 +127,7 @@ func RandBlobTxsWithManualSequence(
 			}
 		}
 
-		msg, blobs := blobfactory.RandMsgPayForBlobsWithSigner(tmrand.NewRand(), addr.String(), randomizedSize, randomizedBlobCount)
+		msg, blobs := blobfactory.RandMsgPayForBlobsWithSigner(random.New(), addr.String(), randomizedSize, randomizedBlobCount)
 		transaction, _, err := signer.CreateTx([]sdk.Msg{msg}, opts...)
 		require.NoError(t, err)
 		if invalidSignature {

--- a/test/util/malicious/app.go
+++ b/test/util/malicious/app.go
@@ -1,12 +1,13 @@
 package malicious
 
 import (
+	"io"
+
 	"cosmossdk.io/log"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"io"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 )

--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -1,12 +1,12 @@
 package malicious
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
 	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
 
 	square "github.com/celestiaorg/go-square/v2"
 	"github.com/celestiaorg/go-square/v2/share"
@@ -15,6 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/da"
 	"github.com/celestiaorg/celestia-app/v4/pkg/wrapper"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )

--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -1,7 +1,7 @@
 package malicious
 
 import (
-	tmrand "cosmossdk.io/math/unsafe"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
 	"math/rand"
@@ -84,7 +84,7 @@ func TestMaliciousTestNode(t *testing.T) {
 	// malicious square builder.
 	client, err := testnode.NewTxClientFromContext(cctx)
 	require.NoError(t, err)
-	blobs := blobfactory.ManyRandBlobs(tmrand.NewRand(), 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000)
+	blobs := blobfactory.ManyRandBlobs(random.New(), 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000)
 	txres, err := client.SubmitPayForBlob(cctx.GoContext(), blobs, blobfactory.DefaultTxOpts()...)
 	require.NoError(t, err)
 	require.Equal(t, abci.CodeTypeOK, txres.Code)

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -1,7 +1,6 @@
 package malicious
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	abci "github.com/cometbft/cometbft/abci/types"
 	core "github.com/cometbft/cometbft/proto/tendermint/types"
 	version "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/ante"
+	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/da"
 )
 

--- a/test/util/random/random.go
+++ b/test/util/random/random.go
@@ -1,0 +1,21 @@
+package random
+
+import (
+	"math/rand"
+	"time"
+)
+
+// New creates a new random object with a random seed.
+func New() *rand.Rand {
+	seed := time.Now().UnixNano()
+	return rand.New(rand.NewSource(seed))
+}
+
+// Bytes generates random bytes using math/rand.
+func Bytes(r *rand.Rand, n int) []byte {
+	bz := make([]byte, n)
+	for i := range bz {
+		bz[i] = byte(r.Intn(256)) // Random byte (0-255)
+	}
+	return bz
+}

--- a/test/util/random/random.go
+++ b/test/util/random/random.go
@@ -12,10 +12,30 @@ func New() *rand.Rand {
 }
 
 // Bytes generates random bytes using math/rand.
-func Bytes(r *rand.Rand, n int) []byte {
+func Bytes(n int) []byte {
+	return BytesR(New(), n)
+}
+
+// BytesR generates a slice of n random bytes using the provided *rand.Rand instance.
+func BytesR(r *rand.Rand, n int) []byte {
 	bz := make([]byte, n)
 	for i := range bz {
 		bz[i] = byte(r.Intn(256)) // Random byte (0-255)
 	}
 	return bz
+}
+
+// Str generates a random string of the given size.
+func Str(n int) string {
+	return StrR(New(), n)
+}
+
+// StrR generates a random string of length n using the provided *rand.Rand instance.
+func StrR(r *rand.Rand, n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	bz := make([]byte, n)
+	for i := range bz {
+		bz[i] = letters[r.Intn(len(letters))]
+	}
+	return string(bz)
 }

--- a/test/util/testfactory/blob.go
+++ b/test/util/testfactory/blob.go
@@ -3,9 +3,8 @@ package testfactory
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
-
-	tmrand "cosmossdk.io/math/unsafe"
 
 	"github.com/celestiaorg/go-square/v2/share"
 
@@ -34,7 +33,7 @@ func GenerateRandomlySizedBlobs(count, maxBlobSize int) []*share.Blob {
 func GenerateBlobsWithNamespace(count, blobSize int, ns share.Namespace) []*share.Blob {
 	blobs := make([]*share.Blob, count)
 	for i := 0; i < count; i++ {
-		blob, err := share.NewBlob(ns, tmrand.Bytes(blobSize), appconsts.DefaultShareVersion, nil)
+		blob, err := share.NewBlob(ns, random.Bytes(blobSize), appconsts.DefaultShareVersion, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -51,7 +50,7 @@ func GenerateBlobsWithNamespace(count, blobSize int, ns share.Namespace) []*shar
 
 func GenerateRandomBlob(dataSize int) *share.Blob {
 	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{0x1}, share.NamespaceVersionZeroIDSize))
-	blob, err := share.NewBlob(ns, tmrand.Bytes(dataSize), appconsts.DefaultShareVersion, nil)
+	blob, err := share.NewBlob(ns, random.Bytes(dataSize), appconsts.DefaultShareVersion, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/test/util/testfactory/blob.go
+++ b/test/util/testfactory/blob.go
@@ -3,12 +3,12 @@ package testfactory
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 
 	"github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 )
 
 func GenerateRandomlySizedBlobs(count, maxBlobSize int) []*share.Blob {

--- a/test/util/testfactory/common.go
+++ b/test/util/testfactory/common.go
@@ -2,9 +2,9 @@ package testfactory
 
 import (
 	"bytes"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sort"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -35,7 +35,7 @@ func Repeat[T any](s T, count int) []T {
 // namespace.
 func GenerateRandNamespacedRawData(count int) (result [][]byte) {
 	for i := 0; i < count; i++ {
-		rawData := tmrand.Bytes(share.ShareSize)
+		rawData := random.Bytes(share.ShareSize)
 		namespace := share.RandomBlobNamespace().Bytes()
 		copy(rawData, namespace)
 		result = append(result, rawData)
@@ -52,7 +52,7 @@ func sortByteArrays(src [][]byte) {
 func RandomAccountNames(count int) []string {
 	accounts := make([]string, 0, count)
 	for i := 0; i < count; i++ {
-		accounts = append(accounts, tmrand.Str(10))
+		accounts = append(accounts, random.Str(10))
 	}
 	return accounts
 }
@@ -60,7 +60,7 @@ func RandomAccountNames(count int) []string {
 func GenerateAccounts(count int) []string {
 	accs := make([]string, count)
 	for i := 0; i < count; i++ {
-		accs[i] = tmrand.Str(20)
+		accs[i] = random.Str(20)
 	}
 	return accs
 }
@@ -106,7 +106,7 @@ func GetAddress(keys keyring.Keyring, account string) sdk.AccAddress {
 }
 
 func RandomEVMAddress() gethcommon.Address {
-	return gethcommon.BytesToAddress(tmrand.Bytes(gethcommon.AddressLength))
+	return gethcommon.BytesToAddress(random.Bytes(gethcommon.AddressLength))
 }
 
 func TestKeyring(cdc codec.Codec, accounts ...string) keyring.Keyring {

--- a/test/util/testfactory/common.go
+++ b/test/util/testfactory/common.go
@@ -2,7 +2,6 @@ package testfactory
 
 import (
 	"bytes"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"sort"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -12,6 +11,8 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 )
 
 const (

--- a/test/util/testfactory/namespace.go
+++ b/test/util/testfactory/namespace.go
@@ -1,11 +1,12 @@
 package testfactory
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"slices"
 
 	"github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 )
 
 // RandomBlobNamespaceIDWithPRG returns a random blob namespace ID using the supplied Pseudo-Random number Generator (PRG).

--- a/test/util/testfactory/namespace.go
+++ b/test/util/testfactory/namespace.go
@@ -1,24 +1,24 @@
 package testfactory
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
+	"math/rand"
 	"slices"
-
-	tmrand "cosmossdk.io/math/unsafe"
 
 	"github.com/celestiaorg/go-square/v2/share"
 )
 
 // RandomBlobNamespaceIDWithPRG returns a random blob namespace ID using the supplied Pseudo-Random number Generator (PRG).
-func RandomBlobNamespaceIDWithPRG(prg *tmrand.Rand) []byte {
-	return prg.Bytes(share.NamespaceVersionZeroIDSize)
+func RandomBlobNamespaceIDWithPRG(r *rand.Rand) []byte {
+	return random.Bytes(r, share.NamespaceVersionZeroIDSize)
 }
 
 func RandomBlobNamespace() share.Namespace {
-	return RandomBlobNamespaceWithPRG(tmrand.NewRand())
+	return RandomBlobNamespaceWithPRG(random.New())
 }
 
 // RandomBlobNamespaceWithPRG generates and returns a random blob namespace using the supplied Pseudo-Random number Generator (PRG).
-func RandomBlobNamespaceWithPRG(rand *tmrand.Rand) share.Namespace {
+func RandomBlobNamespaceWithPRG(rand *rand.Rand) share.Namespace {
 	for {
 		id := RandomBlobNamespaceIDWithPRG(rand)
 		namespace := share.MustNewV0Namespace(id)
@@ -28,7 +28,7 @@ func RandomBlobNamespaceWithPRG(rand *tmrand.Rand) share.Namespace {
 	}
 }
 
-func RandomBlobNamespaces(rand *tmrand.Rand, count int) (namespaces []share.Namespace) {
+func RandomBlobNamespaces(rand *rand.Rand, count int) (namespaces []share.Namespace) {
 	for i := 0; i < count; i++ {
 		namespaces = append(namespaces, RandomBlobNamespaceWithPRG(rand))
 	}

--- a/test/util/testfactory/namespace.go
+++ b/test/util/testfactory/namespace.go
@@ -10,7 +10,7 @@ import (
 
 // RandomBlobNamespaceIDWithPRG returns a random blob namespace ID using the supplied Pseudo-Random number Generator (PRG).
 func RandomBlobNamespaceIDWithPRG(r *rand.Rand) []byte {
-	return random.Bytes(r, share.NamespaceVersionZeroIDSize)
+	return random.BytesR(r, share.NamespaceVersionZeroIDSize)
 }
 
 func RandomBlobNamespace() share.Namespace {

--- a/test/util/testnode/accounts.go
+++ b/test/util/testnode/accounts.go
@@ -1,11 +1,13 @@
 package testnode
 
-import tmrand "cosmossdk.io/math/unsafe"
+import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
+)
 
 // RandomAccounts returns a list of n random accounts
 func RandomAccounts(n int) (accounts []string) {
 	for i := 0; i < n; i++ {
-		account := tmrand.Str(20)
+		account := random.Str(20)
 		accounts = append(accounts, account)
 	}
 	return accounts

--- a/test/util/testnode/comet_node_test.go
+++ b/test/util/testnode/comet_node_test.go
@@ -2,7 +2,6 @@ package testnode
 
 import (
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/test/util/genesis"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )
 

--- a/test/util/testnode/comet_node_test.go
+++ b/test/util/testnode/comet_node_test.go
@@ -2,10 +2,10 @@ package testnode
 
 import (
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmconfig "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -72,7 +72,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 func (s *IntegrationTestSuite) TestPostData() {
 	require := s.Require()
-	_, err := s.cctx.PostData(s.accounts[0], flags.BroadcastSync, share.RandomBlobNamespace(), tmrand.Bytes(kibibyte))
+	_, err := s.cctx.PostData(s.accounts[0], flags.BroadcastSync, share.RandomBlobNamespace(), random.Bytes(kibibyte))
 	require.NoError(err)
 }
 

--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )
 

--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"strings"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmconfig "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/node"
@@ -298,7 +298,7 @@ func (c *Context) FillBlock(squareSize int, account, broadcastMode string) (*sdk
 
 	// we use a formula to guarantee that the tx is the exact size needed to force a specific square size.
 	blobSize := share.AvailableBytesFromSparseShares(shareCount)
-	return c.PostData(account, broadcastMode, share.RandomBlobNamespace(), tmrand.Bytes(blobSize))
+	return c.PostData(account, broadcastMode, share.RandomBlobNamespace(), random.Bytes(blobSize))
 }
 
 // HeightForTimestamp returns the block height for the first block after a

--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -3,12 +3,12 @@ package testnode
 import (
 	"context"
 	"encoding/hex"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"net"
 	"os"
 	"path"
 
 	"cosmossdk.io/math"
-	tmrand "cosmossdk.io/math/unsafe"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -65,7 +65,7 @@ func NewKeyring(accounts ...string) (keyring.Keyring, []sdk.AccAddress) {
 }
 
 func RandomAddress() sdk.Address {
-	name := tmrand.Str(6)
+	name := random.Str(6)
 	_, addresses := NewKeyring(name)
 	return addresses[0]
 }
@@ -89,7 +89,7 @@ func FundKeyringAccounts(accounts ...string) (keyring.Keyring, []banktypes.Balan
 func GenerateAccounts(count int) []string {
 	accs := make([]string, count)
 	for i := 0; i < count; i++ {
-		accs[i] = tmrand.Str(20)
+		accs[i] = random.Str(20)
 	}
 	return accs
 }

--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -3,7 +3,6 @@ package testnode
 import (
 	"context"
 	"encoding/hex"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"net"
 	"os"
 	"path"
@@ -20,6 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 )
 

--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"cosmossdk.io/log"
-	tmrand "cosmossdk.io/math/unsafe"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	tmlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/node"
@@ -38,7 +38,7 @@ func TestRun(t *testing.T) {
 		NumBlocks:     numBlocks,
 		BlockSize:     appconsts.DefaultMaxBytes,
 		BlockInterval: time.Second,
-		ChainID:       tmrand.Str(6),
+		ChainID:       random.Str(6),
 		Namespace:     defaultNamespace,
 	}
 

--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"path/filepath"
 	"testing"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/test/util"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )
 

--- a/tools/chainbuilder/main.go
+++ b/tools/chainbuilder/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"os"
 	"path/filepath"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/genesis"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )

--- a/tools/chainbuilder/main.go
+++ b/tools/chainbuilder/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"os"
 	"path/filepath"
 	"time"
 
 	"cosmossdk.io/log"
-	tmrand "cosmossdk.io/math/unsafe"
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto"
@@ -78,7 +78,7 @@ func main() {
 				BlockInterval: blockInterval,
 				ExistingDir:   existingDir,
 				Namespace:     namespace,
-				ChainID:       tmrand.Str(6),
+				ChainID:       random.Str(6),
 				UpToTime:      upToTime,
 				AppVersion:    appVersion,
 			}

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -1,7 +1,6 @@
 package ante_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,6 +15,7 @@ import (
 	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	ante "github.com/celestiaorg/celestia-app/v4/x/blob/ante"

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -1,9 +1,9 @@
 package ante_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		wantErr               error
 	}
 
-	rand := tmrand.NewRand()
+	rand := random.New()
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 
 	testCases := []testCase{

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -2,7 +2,6 @@ package types_test
 
 import (
 	"bytes"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -20,6 +19,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -2,10 +2,10 @@ package types_test
 
 import (
 	"bytes"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	"cosmossdk.io/math"
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/cometbft/cometbft/crypto/merkle"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -93,7 +93,7 @@ func TestValidateBlobTx(t *testing.T) {
 			name: "invalid transaction, no pfb",
 			getTx: func() *tx.BlobTx {
 				sendTx := blobfactory.GenerateManyRawSendTxs(signer, 1)
-				b, err := types.NewV0Blob(share.RandomBlobNamespace(), tmrand.Bytes(100))
+				b, err := types.NewV0Blob(share.RandomBlobNamespace(), random.Bytes(100))
 				require.NoError(t, err)
 				return &tx.BlobTx{
 					Tx:    sendTx[0],
@@ -108,7 +108,7 @@ func TestValidateBlobTx(t *testing.T) {
 				rawBtx := validRawBtx()
 				btx, _, err := tx.UnmarshalBlobTx(rawBtx)
 				require.NoError(t, err)
-				blob, err := types.NewV0Blob(share.RandomBlobNamespace(), tmrand.Bytes(100))
+				blob, err := types.NewV0Blob(share.RandomBlobNamespace(), random.Bytes(100))
 				require.NoError(t, err)
 				btx.Blobs = append(btx.Blobs, blob)
 				return btx
@@ -118,7 +118,7 @@ func TestValidateBlobTx(t *testing.T) {
 		{
 			name: "invalid share commitment",
 			getTx: func() *tx.BlobTx {
-				b, err := types.NewV0Blob(share.RandomBlobNamespace(), tmrand.Bytes(100))
+				b, err := types.NewV0Blob(share.RandomBlobNamespace(), random.Bytes(100))
 				require.NoError(t, err)
 				msg, err := types.NewMsgPayForBlobs(
 					addr.String(),
@@ -127,7 +127,7 @@ func TestValidateBlobTx(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				anotherBlob, err := share.NewV0Blob(share.RandomBlobNamespace(), tmrand.Bytes(99))
+				anotherBlob, err := share.NewV0Blob(share.RandomBlobNamespace(), random.Bytes(99))
 				require.NoError(t, err)
 				badCommit, err := inclusion.CreateCommitment(
 					anotherBlob,
@@ -155,7 +155,7 @@ func TestValidateBlobTx(t *testing.T) {
 				sendMsg := banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewCoin(app.BondDenom, math.NewInt(10))))
 				transaction := blobfactory.ComplexBlobTxWithOtherMsgs(
 					t,
-					tmrand.NewRand(),
+					random.New(),
 					signer,
 					sendMsg,
 				)

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -2,7 +2,6 @@ package types_test
 
 import (
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"testing"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -2,11 +2,11 @@ package types_test
 
 import (
 	"fmt"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"math/rand"
 	"testing"
 	"time"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
 
@@ -24,7 +24,7 @@ import (
 
 func TestPFBGasEstimation(t *testing.T) {
 	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
-	rand := tmrand.NewRand()
+	rand := random.New()
 
 	testCases := []struct {
 		blobSizes []int
@@ -90,7 +90,7 @@ func FuzzPFBGasEstimation(f *testing.F) {
 		signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accnts[0], 1, 0))
 		require.NoError(t, err)
 
-		rand := tmrand.NewRand()
+		rand := random.New()
 		rand.Seed(seed)
 		blobs := blobfactory.ManyRandBlobs(rand, blobSizes...)
 		gas := blobtypes.DefaultEstimateGas(toUint32(blobSizes))

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -3,7 +3,6 @@ package types_test
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	sdkerrors "cosmossdk.io/errors"
@@ -16,6 +15,7 @@ import (
 	"github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v4/x/blob/types"

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -3,10 +3,10 @@ package types_test
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	sdkerrors "cosmossdk.io/errors"
-	tmrand "cosmossdk.io/math/unsafe"
 	"github.com/cometbft/cometbft/crypto/merkle"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -205,7 +205,7 @@ func TestNewMsgPayForBlobs(t *testing.T) {
 		{
 			name:   "valid msg PFB with large blob",
 			signer: testfactory.TestAccAddr,
-			blobs:  []*share.Blob{mustNewBlob(t, ns1, tmrand.Bytes(1000000), share.ShareVersionZero, nil)},
+			blobs:  []*share.Blob{mustNewBlob(t, ns1, random.Bytes(1000000), share.ShareVersionZero, nil)},
 		},
 		{
 			name:   "valid msg PFB with two blobs",
@@ -220,7 +220,7 @@ func TestNewMsgPayForBlobs(t *testing.T) {
 			name:   "valid msg PFB with share version 1",
 			signer: testfactory.TestAccAddr,
 			blobs: []*share.Blob{
-				mustNewBlob(t, ns1, tmrand.Bytes(10000), share.ShareVersionOne, address),
+				mustNewBlob(t, ns1, random.Bytes(10000), share.ShareVersionOne, address),
 			},
 			expectedErr: false,
 		},
@@ -228,7 +228,7 @@ func TestNewMsgPayForBlobs(t *testing.T) {
 			name:   "msg PFB with tx namespace returns an error",
 			signer: testfactory.TestAccAddr,
 			blobs: []*share.Blob{
-				mustNewBlob(t, share.TxNamespace, tmrand.Bytes(1000000), share.ShareVersionZero, nil),
+				mustNewBlob(t, share.TxNamespace, random.Bytes(1000000), share.ShareVersionZero, nil),
 			},
 			expectedErr: true,
 		},

--- a/x/signal/legacy_test.go
+++ b/x/signal/legacy_test.go
@@ -1,9 +1,9 @@
 package signal_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
-	tmrand "cosmossdk.io/math/unsafe"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
@@ -45,7 +45,7 @@ func (s *LegacyUpgradeTestSuite) SetupSuite() {
 	// we create an arbitrary number of funded accounts
 	accounts := make([]string, 3)
 	for i := 0; i < len(accounts); i++ {
-		accounts[i] = tmrand.Str(9)
+		accounts[i] = random.Str(9)
 	}
 
 	cfg := testnode.DefaultConfig().

--- a/x/signal/legacy_test.go
+++ b/x/signal/legacy_test.go
@@ -1,7 +1,6 @@
 package signal_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
 	"github.com/celestiaorg/celestia-app/v4/test/util/genesis"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testnode"
 )
 


### PR DESCRIPTION
Some functionality was removed from `tmrand`, I just replaced it with a new package which lets you either provide a `rand.Rand` instance, or let it just create one of the fly. All of the usages are in tests, so I don't think removing tmrand matters.