### PR TITLE
chore: skipping integration level inflation test

### DIFF
--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -72,6 +72,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyIncreasesOverTime() {
 // expected rate of inflation. See the README.md for the expected rate of
 // inflation.
 func (s *IntegrationTestSuite) TestInflationRate() {
+	s.T().Skip("inflation rate test skipped due to removal of Block.TimeIotaMs, it is still being tested in abci_test.go")
 	require := s.Require()
 
 	type testCase struct {


### PR DESCRIPTION
Due to removal of `Block.TimeIotaMs` the current setup is no longer possible, however the inflation is being tested in separate begin blocker tests.