### PR TITLE
chore: remove OfferSnapshot custom logic and some versioning logic in tests

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -353,7 +353,7 @@ func New(
 	var transferStack ibcporttypes.IBCModule
 	transferStack = transfer.NewIBCModule(app.TransferKeeper)
 	transferStack = packetforward.NewIBCMiddleware(transferStack, app.PacketForwardKeeper,
-		0,                                                                // retries on timeout
+		0, // retries on timeout
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
 	)
 

--- a/app/app.go
+++ b/app/app.go
@@ -353,7 +353,7 @@ func New(
 	var transferStack ibcporttypes.IBCModule
 	transferStack = transfer.NewIBCModule(app.TransferKeeper)
 	transferStack = packetforward.NewIBCMiddleware(transferStack, app.PacketForwardKeeper,
-		0, // retries on timeout
+		0,                                                                // retries on timeout
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
 	)
 
@@ -520,24 +520,6 @@ func (app *App) InitChainer(ctx sdk.Context, req *abci.RequestInitChain) (*abci.
 	}
 
 	return app.ModuleManager.InitGenesis(ctx, app.AppCodec(), genesisState)
-}
-
-func (app *App) OfferSnapshot(req *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
-	app.Logger().Info("offering snapshot", "height", req.Snapshot.Height, "app_version", req.AppVersion)
-	if req.AppVersion != 0 {
-		if !isSupportedAppVersion(req.AppVersion) {
-			app.Logger().Info("rejecting snapshot because unsupported app version", "app_version", req.AppVersion)
-			return &abci.ResponseOfferSnapshot{
-				Result: abci.ResponseOfferSnapshot_REJECT,
-			}, nil
-		}
-	}
-
-	return app.BaseApp.OfferSnapshot(req)
-}
-
-func isSupportedAppVersion(appVersion uint64) bool {
-	return appVersion == v1 || appVersion == v2 || appVersion == v3 || appVersion == v4
 }
 
 // DefaultGenesis returns the default genesis state

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2,14 +2,10 @@ package app_test
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"cosmossdk.io/log"
-	"cosmossdk.io/store/snapshots"
-	snapshottypes "cosmossdk.io/store/snapshots/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmdb "github.com/cosmos/cosmos-db"
@@ -112,103 +108,6 @@ func TestInitChain(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
-	}
-}
-
-func TestOfferSnapshot(t *testing.T) {
-	t.Run("should ACCEPT a snapshot with app version 0", func(t *testing.T) {
-		// Snapshots taken before the app version field was introduced to RequestOfferSnapshot should still be accepted.
-		app := createTestApp(t)
-		request := createRequest()
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("should ACCEPT a snapshot with app version 1", func(t *testing.T) {
-		app := createTestApp(t)
-		request := createRequest()
-		request.AppVersion = 1
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("should ACCEPT a snapshot with app version 2", func(t *testing.T) {
-		app := createTestApp(t)
-		request := createRequest()
-		request.AppVersion = 2
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("should ACCEPT a snapshot with app version 3", func(t *testing.T) {
-		app := createTestApp(t)
-		request := createRequest()
-		request.AppVersion = 3
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("should ACCEPT a snapshot with app version 4", func(t *testing.T) {
-		app := createTestApp(t)
-		request := createRequest()
-		request.AppVersion = 4
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("should REJECT a snapshot with unsupported app version", func(t *testing.T) {
-		app := createTestApp(t)
-		request := createRequest()
-		request.AppVersion = 5 // unsupported app version
-		want := &abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_REJECT}
-		got, err := app.OfferSnapshot(&request)
-		assert.NoError(t, err)
-		assert.Equal(t, want, got)
-	})
-}
-
-func createTestApp(t *testing.T) *app.App {
-	db := tmdb.NewMemDB()
-	snapshotDir := filepath.Join(t.TempDir(), "data", "snapshots")
-	t.Cleanup(func() {
-		err := os.RemoveAll(snapshotDir)
-		require.NoError(t, err)
-	})
-	snapshotDB, err := tmdb.NewDB("metadata", tmdb.GoLevelDBBackend, snapshotDir)
-	t.Cleanup(func() {
-		err := snapshotDB.Close()
-		require.NoError(t, err)
-	})
-	require.NoError(t, err)
-	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
-	require.NoError(t, err)
-	baseAppOption := baseapp.SetSnapshot(snapshotStore, snapshottypes.NewSnapshotOptions(10, 10))
-	testApp := app.New(log.NewNopLogger(), db, nil, 0, util.EmptyAppOptions{}, baseAppOption)
-	require.NoError(t, err)
-	response, err := testApp.Info(&abci.RequestInfo{})
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), response.AppVersion)
-	return testApp
-}
-
-func createRequest() abci.RequestOfferSnapshot {
-	return abci.RequestOfferSnapshot{
-		// Snapshot was created by logging the contents of OfferSnapshot on a
-		// node that was syncing via state sync.
-		Snapshot: &abci.Snapshot{
-			Height:   0x1b07ec,
-			Format:   0x3,
-			Chunks:   0x1,
-			Hash:     []uint8{0xaf, 0xa5, 0xe, 0x16, 0x45, 0x4, 0x2e, 0x45, 0xd3, 0x49, 0xdf, 0x83, 0x2a, 0x57, 0x9d, 0x64, 0xc8, 0xad, 0xa5, 0xb, 0x65, 0x1b, 0x46, 0xd6, 0xc3, 0x85, 0x6, 0x51, 0xd7, 0x45, 0x8e, 0xb8},
-			Metadata: []uint8{0xa, 0x20, 0xaf, 0xa5, 0xe, 0x16, 0x45, 0x4, 0x2e, 0x45, 0xd3, 0x49, 0xdf, 0x83, 0x2a, 0x57, 0x9d, 0x64, 0xc8, 0xad, 0xa5, 0xb, 0x65, 0x1b, 0x46, 0xd6, 0xc3, 0x85, 0x6, 0x51, 0xd7, 0x45, 0x8e, 0xb8},
-		},
-		AppHash:    []byte("apphash"),
-		AppVersion: 0, // unit tests will override this
 	}
 }
 

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -11,18 +11,15 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	v1 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v1"
-	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	ante "github.com/celestiaorg/celestia-app/v4/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )
 
 func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 	type testCase struct {
-		name       string
-		pfb        *blob.MsgPayForBlobs
-		appVersion uint64
-		wantErr    error
+		name    string
+		pfb     *blob.MsgPayForBlobs
+		wantErr error
 	}
 
 	testCases := []testCase{
@@ -31,28 +28,27 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1},
 			},
-			appVersion: v2.Version,
+			wantErr: nil,
 		},
 		{
 			name: "PFB with 1 blob that is 1 byte",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1},
 			},
-			appVersion: v1.Version,
+			wantErr: nil,
 		},
 		{
 			name: "PFB with 1 blob that is 1 MiB",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{mebibyte},
 			},
-			appVersion: v1.Version,
+			wantErr: nil,
 		},
 		{
 			name: "PFB with 1 blob that is 2 MiB",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{2 * mebibyte},
 			},
-			appVersion: v1.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
 			// will be slightly smaller than 2 MiB.
@@ -63,14 +59,12 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1, 1},
 			},
-			appVersion: v1.Version,
 		},
 		{
 			name: "PFB with 2 blobs that are 1 MiB each",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{mebibyte, mebibyte},
 			},
-			appVersion: v1.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.
 			wantErr: blob.ErrTotalBlobSizeTooLarge,
@@ -80,21 +74,18 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(share.AvailableBytesFromSparseShares(1))},
 			},
-			appVersion: v1.Version,
 		},
 		{
 			name: "PFB with 1 blob that occupies total square - 1",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(share.AvailableBytesFromSparseShares((squareSize * squareSize) - 1))},
 			},
-			appVersion: v1.Version,
 		},
 		{
 			name: "PFB with 1 blob that occupies total square",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(share.AvailableBytesFromSparseShares(squareSize * squareSize))},
 			},
-			appVersion: v1.Version,
 			// This test case should return an error because if the blob
 			// occupies the total square, there is no space for the PFB tx
 			// share.
@@ -108,7 +99,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 					uint32(share.AvailableBytesFromSparseShares(1)),
 				},
 			},
-			appVersion: v1.Version,
+			wantErr: nil,
 		},
 		{
 			name: "PFB with 2 blobs that occupy half the square each",
@@ -118,8 +109,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 					uint32(share.AvailableBytesFromSparseShares(squareSize * squareSize / 2)),
 				},
 			},
-			appVersion: v1.Version,
-			wantErr:    blob.ErrTotalBlobSizeTooLarge,
+			wantErr: blob.ErrTotalBlobSizeTooLarge,
 		},
 	}
 


### PR DESCRIPTION

This PR removes the custom OfferSnapshot behaviour based on the celestia specific AppVersion field on the `req *abci.RequestOfferSnapshot`. 

My understanding is that earlier versions (i.e. embedded binaries) should handle requests like this to earlier versions. Any `RequestOfferSnapshot` requests here are v4 specific, and the `AppVersion` field is irrelevant.

I also removed the `appVersion` field in some tests, as they do not actually matter here anymore.