### PR TITLE
chore: remove versioning from blob share decorator test and signer type

### DIFF
--- a/app/ante/max_tx_size_test.go
+++ b/app/ante/max_tx_size_test.go
@@ -1,7 +1,6 @@
 package ante_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"testing"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -9,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-app/v4/app/ante"
+	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 )
 
 func TestMaxTxSizeDecorator(t *testing.T) {

--- a/app/ante/max_tx_size_test.go
+++ b/app/ante/max_tx_size_test.go
@@ -1,15 +1,14 @@
 package ante_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"testing"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	version "github.com/cometbft/cometbft/proto/tendermint/version"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/celestia-app/v4/app/ante"
-	v3 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v4"
 )
 
 func TestMaxTxSizeDecorator(t *testing.T) {
@@ -20,48 +19,33 @@ func TestMaxTxSizeDecorator(t *testing.T) {
 		name        string
 		txSize      int
 		expectError bool
-		appVersion  uint64
 		isCheckTx   []bool
 	}{
 		{
 			name:        "good tx; under max tx size threshold",
-			txSize:      v3.MaxTxSize - 1,
-			appVersion:  v3.Version,
+			txSize:      appconsts.DefaultMaxTxSize - 1,
 			expectError: false,
 			isCheckTx:   []bool{true, false},
 		},
 		{
 			name:        "bad tx; over max tx size threshold",
-			txSize:      v3.MaxTxSize + 1,
-			appVersion:  v3.Version,
+			txSize:      appconsts.DefaultMaxTxSize + 1,
 			expectError: true,
 			isCheckTx:   []bool{true, false},
 		},
 		{
 			name:        "good tx; equal to max tx size threshold",
-			txSize:      v3.MaxTxSize,
-			appVersion:  v3.Version,
+			txSize:      appconsts.DefaultMaxTxSize,
 			expectError: false,
 			isCheckTx:   []bool{true, false},
 		},
-		//{
-		//	name:        "good tx; limit only applies to v3 and above",
-		//	txSize:      v3.MaxTxSize + 10,
-		//	appVersion:  v2.Version,
-		//	expectError: false,
-		//	isCheckTx:   []bool{true, false},
-		// },
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, isCheckTx := range tc.isCheckTx {
 
-				ctx := sdk.NewContext(nil, tmproto.Header{
-					Version: version.Consensus{
-						App: tc.appVersion,
-					},
-				}, isCheckTx, nil)
+				ctx := sdk.NewContext(nil, tmproto.Header{}, isCheckTx, nil)
 
 				txBytes := make([]byte, tc.txSize)
 

--- a/app/benchmarks/benchmark_ibc_update_client_test.go
+++ b/app/benchmarks/benchmark_ibc_update_client_test.go
@@ -246,7 +246,7 @@ func generateIBCUpdateClientTransaction(b *testing.B, numberOfValidators, number
 	addr := testfactory.GetAddress(kr, account)
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	acc := testutil.DirectQueryAccount(testApp, addr)
-	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
 	require.NoError(b, err)
 
 	msgs := generateUpdateClientTransaction(

--- a/app/benchmarks/benchmark_msg_send_test.go
+++ b/app/benchmarks/benchmark_msg_send_test.go
@@ -263,7 +263,7 @@ func generateMsgSendTransactions(b *testing.B, count int) (*app.App, [][]byte) {
 	addr := testfactory.GetAddress(kr, account)
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	acc := testutil.DirectQueryAccount(testApp, addr)
-	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
 	require.NoError(b, err)
 	rawTxs := make([][]byte, 0, count)
 	for i := 0; i < count; i++ {

--- a/app/benchmarks/benchmark_pfb_test.go
+++ b/app/benchmarks/benchmark_pfb_test.go
@@ -344,7 +344,7 @@ func generatePayForBlobTransactions(b *testing.B, count, size int) (*app.App, []
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	acc := testutil.DirectQueryAccount(testApp, addr)
 	accountSequence := acc.GetSequence()
-	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
 	require.NoError(b, err)
 
 	rawTxs := make([][]byte, 0, count)

--- a/app/errors/insufficient_gas_price_test.go
+++ b/app/errors/insufficient_gas_price_test.go
@@ -41,7 +41,7 @@ func TestInsufficientMinGasPriceIntegration(t *testing.T) {
 
 	encodingCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 
-	signer, err := user.NewSigner(kr, encodingCfg.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
+	signer, err := user.NewSigner(kr, encodingCfg.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
 	require.NoError(t, err)
 
 	b, err := blob.NewV0Blob(share.RandomNamespace(), []byte("hello world"))

--- a/app/errors/nonce_mismatch_test.go
+++ b/app/errors/nonce_mismatch_test.go
@@ -35,7 +35,7 @@ func TestNonceMismatchIntegration(t *testing.T) {
 	acc := testutil.DirectQueryAccount(testApp, addr)
 
 	// set the sequence to an incorrect value
-	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()+1))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()+1))
 	require.NoError(t, err)
 
 	b, err := blob.NewV0Blob(share.RandomNamespace(), []byte("hello world"))

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -267,7 +267,7 @@ func TestCheckTx(t *testing.T) {
 func createSigner(t *testing.T, kr keyring.Keyring, accountName string, enc client.TxConfig, accNum uint64) *user.Signer {
 	t.Helper()
 
-	signer, err := user.NewSigner(kr, enc, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accountName, accNum, 0))
+	signer, err := user.NewSigner(kr, enc, testutil.ChainID, user.NewAccount(accountName, accNum, 0))
 	require.NoError(t, err)
 	return signer
 }

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -268,7 +268,7 @@ func TestPrepareProposalCappingNumberOfMessages(t *testing.T) {
 		addrs = append(addrs, addr)
 		acc := testutil.DirectQueryAccount(testApp, addrs[index])
 		accs = append(accs, acc)
-		signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
+		signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(account, acc.GetAccountNumber(), acc.GetSequence()))
 		require.NoError(t, err)
 		signers = append(signers, signer)
 	}

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -34,7 +34,7 @@ func TestProcessProposal(t *testing.T) {
 	accounts := testfactory.GenerateAccounts(6)
 	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	infos := queryAccountInfo(testApp, accounts, kr)
-	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accounts[0], infos[0].AccountNum, infos[0].Sequence))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(accounts[0], infos[0].AccountNum, infos[0].Sequence))
 	require.NoError(t, err)
 
 	// create 4 single blob blobTxs that are signed with valid account numbers

--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -213,7 +213,6 @@ func SetupTxClient(
 	}
 
 	chainID := resp.SdkBlock.Header.ChainID
-	appVersion := resp.SdkBlock.Header.Version.App
 
 	records, err := keys.List()
 	if err != nil {
@@ -242,7 +241,7 @@ func SetupTxClient(
 	}
 	options = append([]Option{WithDefaultGasPrice(minPrice)}, options...)
 
-	signer, err := NewSigner(keys, encCfg.TxConfig, chainID, appVersion, accounts...)
+	signer, err := NewSigner(keys, encCfg.TxConfig, chainID, accounts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create signer: %w", err)
 	}

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -252,7 +252,7 @@ func ManyMultiBlobTx(
 	t.Helper()
 	txs := make([][]byte, len(accounts))
 	for i, acc := range accounts {
-		signer, err := user.NewSigner(kr, enc, chainid, appconsts.LatestVersion, user.NewAccount(acc, accInfos[i].AccountNum, accInfos[i].Sequence))
+		signer, err := user.NewSigner(kr, enc, chainid, user.NewAccount(acc, accInfos[i].AccountNum, accInfos[i].Sequence))
 		require.NoError(t, err)
 		txs[i], _, err = signer.CreatePayForBlobs(acc, blobs[i], DefaultTxOpts()...)
 		require.NoError(t, err)

--- a/test/util/blobfactory/test_util_test.go
+++ b/test/util/blobfactory/test_util_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
@@ -24,7 +23,7 @@ func TestGenerateManyRandomRawSendTxsSameSigner_Deterministic(t *testing.T) {
 	TxDecoder := enc.TxConfig.TxDecoder()
 
 	kr, _ := testnode.NewKeyring(testfactory.TestAccName)
-	signer, err := user.NewSigner(kr, enc.TxConfig, testfactory.ChainID, appconsts.LatestVersion, user.NewAccount(testfactory.TestAccName, 1, 0))
+	signer, err := user.NewSigner(kr, enc.TxConfig, testfactory.ChainID, user.NewAccount(testfactory.TestAccName, 1, 0))
 	require.NoError(t, err)
 
 	encodedTxs1 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(rand.New(rand.NewSource(seed)), signer, normalTxCount)

--- a/test/util/direct_tx_gen.go
+++ b/test/util/direct_tx_gen.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/params"
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/random"
@@ -46,14 +45,11 @@ func RandBlobTxsWithAccounts(
 
 	txs := make([]coretypes.Tx, len(accounts))
 
-	appVersion, err := capp.AppVersion(capp.NewContext(true))
-	require.NoError(t, err)
-
 	for i := 0; i < len(accounts); i++ {
 		addr := testfactory.GetAddress(kr, accounts[i])
 		acc := DirectQueryAccount(capp, addr)
 		account := user.NewAccount(accounts[i], acc.GetAccountNumber(), acc.GetSequence())
-		signer, err := user.NewSigner(kr, cfg, chainid, appVersion, account)
+		signer, err := user.NewSigner(kr, cfg, chainid, account)
 		require.NoError(t, err)
 
 		randomizedSize := size
@@ -109,7 +105,7 @@ func RandBlobTxsWithManualSequence(
 	for i := 0; i < len(accounts); i++ {
 		addr := testfactory.GetAddress(kr, accounts[i])
 		acc := user.NewAccount(accounts[i], accountNum, sequence)
-		signer, err := user.NewSigner(kr, cfg, chainid, appconsts.LatestVersion, acc)
+		signer, err := user.NewSigner(kr, cfg, chainid, acc)
 		require.NoError(t, err)
 
 		randomizedSize := size
@@ -217,7 +213,7 @@ func SendTxWithManualSequence(
 	opts ...user.TxOption,
 ) coretypes.Tx {
 	fromAddr, toAddr := getAddress(fromAcc, kr), getAddress(toAcc, kr)
-	signer, err := user.NewSigner(kr, cfg, chainid, appconsts.LatestVersion, user.NewAccount(fromAcc, accountNum, sequence))
+	signer, err := user.NewSigner(kr, cfg, chainid, user.NewAccount(fromAcc, accountNum, sequence))
 	require.NoError(t, err)
 
 	msg := banktypes.NewMsgSend(fromAddr, toAddr, sdk.NewCoins(sdk.NewCoin(params.BondDenom, math.NewIntFromUint64(amount))))

--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -241,7 +241,7 @@ func (c *Context) PostData(account, broadcastMode string, ns share.Namespace, bl
 	}
 
 	// use the key for accounts[i] to create a signer used for a single PFB
-	signer, err := user.NewSigner(c.Keyring, c.TxConfig, c.ChainID, appconsts.LatestVersion, user.NewAccount(account, acc, seq))
+	signer, err := user.NewSigner(c.Keyring, c.TxConfig, c.ChainID, user.NewAccount(account, acc, seq))
 	if err != nil {
 		return nil, err
 	}

--- a/test/util/testnode/signer.go
+++ b/test/util/testnode/signer.go
@@ -3,7 +3,6 @@ package testnode
 import (
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
 )
@@ -11,7 +10,7 @@ import (
 func NewOfflineSigner() (*user.Signer, error) {
 	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	kr, _ := NewKeyring(testfactory.TestAccName)
-	return user.NewSigner(kr, encCfg.TxConfig, testfactory.ChainID, appconsts.LatestVersion, user.NewAccount(testfactory.TestAccName, 0, 0))
+	return user.NewSigner(kr, encCfg.TxConfig, testfactory.ChainID, user.NewAccount(testfactory.TestAccName, 0, 0))
 }
 
 func NewTxClientFromContext(ctx Context) (*user.TxClient, error) {

--- a/tools/chainbuilder/main.go
+++ b/tools/chainbuilder/main.go
@@ -285,13 +285,7 @@ func Run(ctx context.Context, cfg BuilderConfig, dir string) error {
 
 	validatorPower := state.Validators.Validators[0].VotingPower
 
-	signer, err := user.NewSigner(
-		kr,
-		encCfg.TxConfig,
-		state.ChainID,
-		state.ConsensusParams.Version.App,
-		user.NewAccount(testnode.DefaultValidatorAccountName, 0, uint64(lastHeight)+1),
-	)
+	signer, err := user.NewSigner(kr, encCfg.TxConfig, state.ChainID, user.NewAccount(testnode.DefaultValidatorAccountName, 0, uint64(lastHeight)+1))
 	if err != nil {
 		return fmt.Errorf("failed to create new signer: %w", err)
 	}

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	v2 "github.com/celestiaorg/celestia-app/v4/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v4/pkg/user"
 	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v4/test/util/random"
@@ -31,7 +31,6 @@ func TestBlobShareDecorator(t *testing.T) {
 	type testCase struct {
 		name                  string
 		blobsPerPFB, blobSize int
-		appVersion            uint64
 		wantErr               error
 	}
 
@@ -43,19 +42,16 @@ func TestBlobShareDecorator(t *testing.T) {
 			name:        "PFB with 1 blob that is 1 byte",
 			blobsPerPFB: 1,
 			blobSize:    1,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that is 1 MiB",
 			blobsPerPFB: 1,
 			blobSize:    1 * mebibyte,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that is 2 MiB",
 			blobsPerPFB: 1,
 			blobSize:    2 * mebibyte,
-			appVersion:  v2.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
 			// will be slightly smaller than 2 MiB.
@@ -65,13 +61,11 @@ func TestBlobShareDecorator(t *testing.T) {
 			name:        "PFB with 2 blobs that are 1 byte each",
 			blobsPerPFB: 2,
 			blobSize:    1,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 2 blobs that are 1 MiB each",
 			blobsPerPFB: 2,
 			blobSize:    1 * mebibyte,
-			appVersion:  v2.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.
 			wantErr: blob.ErrBlobsTooLarge,
@@ -80,32 +74,27 @@ func TestBlobShareDecorator(t *testing.T) {
 			name:        "PFB with many single byte blobs should fit",
 			blobsPerPFB: 3000,
 			blobSize:    1,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with too many single byte blobs should not fit",
 			blobsPerPFB: 4000,
 			blobSize:    1,
-			appVersion:  v2.Version,
 			wantErr:     blob.ErrBlobsTooLarge,
 		},
 		{
 			name:        "PFB with 1 blob that is 1 share",
 			blobsPerPFB: 1,
 			blobSize:    100,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that occupies total square - 1",
 			blobsPerPFB: 1,
 			blobSize:    share.AvailableBytesFromSparseShares(squareSize*squareSize - 1),
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that occupies total square",
 			blobsPerPFB: 1,
 			blobSize:    share.AvailableBytesFromSparseShares(squareSize * squareSize),
-			appVersion:  v2.Version,
 			// This test case should return an error because if the blob
 			// occupies the total square, there is no space for the PFB tx
 			// share.
@@ -115,13 +104,11 @@ func TestBlobShareDecorator(t *testing.T) {
 			name:        "PFB with 2 blobs that are 1 share each",
 			blobsPerPFB: 2,
 			blobSize:    100,
-			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 2 blobs that occupy half the square each",
 			blobsPerPFB: 2,
 			blobSize:    share.AvailableBytesFromSparseShares(squareSize * squareSize / 2),
-			appVersion:  v2.Version,
 			wantErr:     blob.ErrBlobsTooLarge,
 		},
 	}
@@ -133,7 +120,7 @@ func TestBlobShareDecorator(t *testing.T) {
 				kr,
 				enc.TxConfig,
 				testfactory.ChainID,
-				tc.appVersion,
+				appconsts.LatestVersion,
 				user.NewAccount(testfactory.TestAccName, 1, 0),
 			)
 			require.NoError(t, err)

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -1,7 +1,6 @@
 package ante_test
 
 import (
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -116,13 +115,7 @@ func TestBlobShareDecorator(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			kr, _ := testnode.NewKeyring(testfactory.TestAccName)
-			signer, err := user.NewSigner(
-				kr,
-				enc.TxConfig,
-				testfactory.ChainID,
-				appconsts.LatestVersion,
-				user.NewAccount(testfactory.TestAccName, 1, 0),
-			)
+			signer, err := user.NewSigner(kr, enc.TxConfig, testfactory.ChainID, user.NewAccount(testfactory.TestAccName, 1, 0))
 			require.NoError(t, err)
 
 			blobTx := blobfactory.RandBlobTxs(signer, rand, 1, tc.blobsPerPFB, tc.blobSize)

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -24,7 +24,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "want no error if appVersion v2 and 8 MiB blob",
+			name: "want no error with 8 MiB blob",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1},
 			},

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestPFBGasEstimation(t *testing.T) {
 	encCfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
-	rand := random.New()
+	rnd := random.New()
 
 	testCases := []struct {
 		blobSizes []int
@@ -41,9 +41,9 @@ func TestPFBGasEstimation(t *testing.T) {
 		t.Run(fmt.Sprintf("case %d", idx), func(t *testing.T) {
 			accnts := testfactory.GenerateAccounts(1)
 			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultInitialConsensusParams(), accnts...)
-			signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accnts[0], 1, 0))
+			signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accnts[0], 1, 0))
 			require.NoError(t, err)
-			blobs := blobfactory.ManyRandBlobs(rand, tc.blobSizes...)
+			blobs := blobfactory.ManyRandBlobs(rnd, tc.blobSizes...)
 			gas := blobtypes.DefaultEstimateGas(toUint32(tc.blobSizes))
 			tx, _, err := signer.CreatePayForBlobs(accnts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
 			require.NoError(t, err)
@@ -87,12 +87,12 @@ func FuzzPFBGasEstimation(f *testing.F) {
 
 		accnts := testfactory.GenerateAccounts(1)
 		testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
-		signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accnts[0], 1, 0))
+		signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accnts[0], 1, 0))
 		require.NoError(t, err)
 
-		rand := random.New()
-		rand.Seed(seed)
-		blobs := blobfactory.ManyRandBlobs(rand, blobSizes...)
+		rnd := random.New()
+		rnd.Seed(seed)
+		blobs := blobfactory.ManyRandBlobs(rnd, blobSizes...)
 		gas := blobtypes.DefaultEstimateGas(toUint32(blobSizes))
 		tx, _, err := signer.CreatePayForBlobs(accnts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
 		require.NoError(t, err)


### PR DESCRIPTION
This PR:
- removes appVersion from TestMaxTxSizeDecorator and TestBlobShareDecorator
- removes the appVersion from the Signer type as the field is no longer used.