### PR TITLE
chore: add debug commands

### DIFF
--- a/app/ante/fee.go
+++ b/app/ante/fee.go
@@ -21,6 +21,11 @@ const (
 // ante.NewDeductFeeDecorator whilst still satisfying the ante.TxFeeChecker type.
 func ValidateTxFeeWrapper(paramKeeper params.Keeper) ante.TxFeeChecker {
 	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+		if ctx.BlockHeight() == 0 {
+			// genesis block, no need to validate fees
+			return nil, 0, nil
+		}
+
 		return ValidateTxFee(ctx, tx, paramKeeper)
 	}
 }

--- a/cmd/celestia-appd/cmd/genesis_helper.go
+++ b/cmd/celestia-appd/cmd/genesis_helper.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/server"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 )
 
 // AppGenesisToCometGenesisConverterCmd returns a command that converts the app genesis to comet genesis.

--- a/cmd/celestia-appd/cmd/genesis_helper.go
+++ b/cmd/celestia-appd/cmd/genesis_helper.go
@@ -12,7 +12,8 @@ func AppGenesisToCometGenesisConverterCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "convert-genesis",
 		Short: "Convert app genesis to comet genesis",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			serverCtx := server.GetServerContextFromCmd(cmd)
 
 			appGenesis, err := genutiltypes.AppGenesisFromFile(serverCtx.Config.GenesisFile())

--- a/cmd/celestia-appd/cmd/genesis_helper.go
+++ b/cmd/celestia-appd/cmd/genesis_helper.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+)
+
+// AppGenesisToCometGenesisConverterCmd returns a command that converts the app genesis to comet genesis.
+func AppGenesisToCometGenesisConverterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "convert-genesis",
+		Short: "Convert app genesis to comet genesis",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			serverCtx := server.GetServerContextFromCmd(cmd)
+
+			appGenesis, err := genutiltypes.AppGenesisFromFile(serverCtx.Config.GenesisFile())
+			if err != nil {
+				return err
+			}
+
+			genDoc, err := appGenesis.ToGenesisDoc()
+			if err != nil {
+				return err
+			}
+
+			if err := genDoc.ValidateAndComplete(); err != nil {
+				return err
+			}
+
+			if err := genDoc.SaveAs(serverCtx.Config.GenesisFile()); err != nil {
+				return err
+			}
+
+			cmd.Println("successfully converted app genesis to comet genesis")
+			return nil
+		},
+	}
+}

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -115,8 +115,10 @@ func initRootCommand(rootCommand *cobra.Command, capp *app.App) {
 	versions := Versions()
 
 	debugCmd := debug.Cmd()
-	debugCmd.AddCommand(NewInPlaceTestnetCmd())
-
+	debugCmd.AddCommand(
+		NewInPlaceTestnetCmd(),
+		AppGenesisToCometGenesisConverterCmd(),
+	)
 	passthroughCmd, _ := nova.NewPassthroughCmd(versions)
 	// TODO: handle the error here. (currently breaking ledger tests as they do a cli exec and the expected binary bytes are not there)
 

--- a/go.mod
+++ b/go.mod
@@ -89,16 +89,15 @@ require (
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect
 	github.com/bufbuild/protocompile v0.14.1 // indirect
-	github.com/bytedance/sonic v1.12.3 // indirect
-	github.com/bytedance/sonic/loader v0.2.0 // indirect
+	github.com/bytedance/sonic v1.13.1 // indirect
+	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7 // indirect
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cilium/ebpf v0.12.3 // indirect
-	github.com/cloudwego/base64x v0.1.4 // indirect
-	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -330,11 +330,11 @@ github.com/btcsuite/btcd/btcutil v1.1.6 h1:zFL2+c3Lb9gEgqKNzowKUPQNb8jV7v5Oaodi/
 github.com/btcsuite/btcd/btcutil v1.1.6/go.mod h1:9dFymx8HpuLqBnsPELrImQeTQfKBQqzqGbbV3jK55aE=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
-github.com/bytedance/sonic v1.12.3 h1:W2MGa7RCU1QTeYRTPE3+88mVC0yXmsRQRChiyVocVjU=
-github.com/bytedance/sonic v1.12.3/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
+github.com/bytedance/sonic v1.13.1 h1:Jyd5CIvdFnkOWuKXr+wm4Nyk2h0yAFsr8ucJgEasO3g=
+github.com/bytedance/sonic v1.13.1/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/bytedance/sonic/loader v0.2.0 h1:zNprn+lsIP06C/IqCHs3gPQIvnvpKbbxyXQP1iU4kWM=
-github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
+github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
+github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7 h1:nxplQi8wrLMjhu260RuigXylC3pWoDu4OVumPHeojnk=
 github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7/go.mod h1:1EF5MfOxVf0WC51Gb7pJ6bcZxnXKNAf9pqWtjgPBAYc=
@@ -374,9 +374,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
-github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
-github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
+github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
+github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
https://github.com/01builders/celestia-app/pull/57 isn't meant to be merged. this bring in fixes + helper found along the way.

- new debug command, helps when running comet out of process (not via nova), to convert a sdk genesis to comet genesis
- starting the chain with init.sh (local_devnet) wasn't possible. no fees should be expected at genesis.
- bumps sonic lib to avoid annoying prints line with go 1.24