### PR TITLE
chore: feedback from celestiaorg/celestia-app#4430

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -521,20 +521,20 @@ func (app *App) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 	}
 
 	// use a signaling mechanism for upgrade
-	shouldUpgrade, newVersion := app.SignalKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade := app.SignalKeeper.ShouldUpgrade(ctx)
 	if shouldUpgrade {
 		// Version changes must be increasing. Downgrades are not permitted
-		if newVersion.AppVersion > currentVersion {
-			app.BaseApp.Logger().Info("upgrading app version", "current version", currentVersion, "new version", newVersion)
+		if upgrade.AppVersion > currentVersion {
+			app.BaseApp.Logger().Info("upgrading app version", "current version", currentVersion, "new version", upgrade.AppVersion)
 
 			if err := app.UpgradeKeeper.ScheduleUpgrade(ctx, upgradetypes.Plan{
-				Name:   fmt.Sprintf("v%d", newVersion.AppVersion),
-				Height: newVersion.UpgradeHeight,
+				Name:   fmt.Sprintf("v%d", upgrade.AppVersion),
+				Height: upgrade.UpgradeHeight,
 			}); err != nil {
 				return sdk.EndBlock{}, fmt.Errorf("failed to schedule upgrade: %v", err)
 			}
 
-			if err := app.SetAppVersion(ctx, newVersion.AppVersion); err != nil {
+			if err := app.SetAppVersion(ctx, upgrade.AppVersion); err != nil {
 				return sdk.EndBlock{}, err
 			}
 			app.SignalKeeper.ResetTally(ctx)

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -19,7 +19,11 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			chainID:                    appconsts.TestChainID,
 			expectedUpgradeHeightDelay: 3,
 		},
-
+		{
+			name:                       "the upgrade delay for chainID 'local_devnet' should be 3",
+			chainID:                    appconsts.LocalDevnetChainID,
+			expectedUpgradeHeightDelay: 3,
+		},
 		{
 			name:                       "the upgrade delay should be latest value",
 			chainID:                    "arabica-11",

--- a/x/signal/integration_test.go
+++ b/x/signal/integration_test.go
@@ -84,13 +84,13 @@ func TestUpgradeIntegration(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrUpgradePending)
 
-	shouldUpgrade, version := app.SignalKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade := app.SignalKeeper.ShouldUpgrade(ctx)
 	require.False(t, shouldUpgrade)
-	require.EqualValues(t, 0, version.AppVersion)
+	require.EqualValues(t, 0, upgrade.AppVersion)
 
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.UpgradeHeightDelay(appconsts.TestChainID))
 
-	shouldUpgrade, version = app.SignalKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade = app.SignalKeeper.ShouldUpgrade(ctx)
 	require.True(t, shouldUpgrade)
-	require.EqualValues(t, 3, version.AppVersion)
+	require.EqualValues(t, 3, upgrade.AppVersion)
 }

--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -232,8 +232,8 @@ func (k Keeper) GetVotingPowerThreshold(ctx sdk.Context) (math.Int, error) {
 }
 
 // ShouldUpgrade returns whether the signalling mechanism has concluded that the
-// network is ready to upgrade and the version to upgrade to. It returns false
-// and 0 if no version has reached quorum.
+// network is ready to upgrade and the upgrade. It returns false
+// and an empty upgrade if no version has reached quorum.
 func (k *Keeper) ShouldUpgrade(ctx sdk.Context) (isQuorumVersion bool, upgrade types.Upgrade) {
 	upgrade, ok := k.getUpgrade(ctx)
 	if !ok {

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -166,9 +166,9 @@ func TestTallyingLogic(t *testing.T) {
 
 	_, err = upgradeKeeper.TryUpgrade(ctx, &types.MsgTryUpgrade{})
 	require.NoError(t, err)
-	shouldUpgrade, version := upgradeKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade := upgradeKeeper.ShouldUpgrade(ctx)
 	require.False(t, shouldUpgrade)
-	require.Equal(t, uint64(0), version.AppVersion)
+	require.Equal(t, uint64(0), upgrade.AppVersion)
 
 	// we now have 101/120
 	_, err = upgradeKeeper.SignalVersion(ctx, &types.MsgSignalVersion{
@@ -180,15 +180,15 @@ func TestTallyingLogic(t *testing.T) {
 	_, err = upgradeKeeper.TryUpgrade(ctx, &types.MsgTryUpgrade{})
 	require.NoError(t, err)
 
-	shouldUpgrade, version = upgradeKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade = upgradeKeeper.ShouldUpgrade(ctx)
 	require.False(t, shouldUpgrade) // should be false because upgrade height hasn't been reached.
-	require.Equal(t, uint64(0), version.AppVersion)
+	require.Equal(t, uint64(0), upgrade.AppVersion)
 
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.UpgradeHeightDelay(appconsts.TestChainID))
 
-	shouldUpgrade, version = upgradeKeeper.ShouldUpgrade(ctx)
+	shouldUpgrade, upgrade = upgradeKeeper.ShouldUpgrade(ctx)
 	require.True(t, shouldUpgrade) // should be true because upgrade height has been reached.
-	require.Equal(t, v2.Version, version.AppVersion)
+	require.Equal(t, v2.Version, upgrade.AppVersion)
 
 	upgradeKeeper.ResetTally(ctx)
 


### PR DESCRIPTION
Follow-up of https://github.com/01builders/celestia-app/pull/68.
Implementing feedback from https://github.com/celestiaorg/celestia-app/pull/4430 to keep both implementation indentical.
Cherry-picks https://github.com/celestiaorg/celestia-app/pull/4430/commits/4853c57983876c97368176340815dae72f9399cd