### PR TITLE
test: fix gas estimation benchmarks

### DIFF
--- a/app/benchmarks/gas_estimator_test.go
+++ b/app/benchmarks/gas_estimator_test.go
@@ -6,31 +6,34 @@ import (
 	"context"
 	"testing"
 
-	"github.com/celestiaorg/celestia-app/v4/app"
-	"github.com/celestiaorg/celestia-app/v4/app/encoding"
-	"github.com/celestiaorg/celestia-app/v4/app/grpc/gasestimation"
-	"github.com/celestiaorg/celestia-app/v4/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/v4/pkg/user"
-	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
-	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
-	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
-	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
-	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/cometbft/cometbft/rpc/client"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	tmrand "github.com/tendermint/tendermint/libs/rand"
-	"github.com/tendermint/tendermint/rpc/client"
-	rpctypes "github.com/tendermint/tendermint/rpc/core/types"
-	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/go-square/v2/share"
+
+	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/v4/app/encoding"
+	"github.com/celestiaorg/celestia-app/v4/app/grpc/gasestimation"
+	"github.com/celestiaorg/celestia-app/v4/pkg/user"
+	testutil "github.com/celestiaorg/celestia-app/v4/test/util"
+	"github.com/celestiaorg/celestia-app/v4/test/util/blobfactory"
+	"github.com/celestiaorg/celestia-app/v4/test/util/random"
+	"github.com/celestiaorg/celestia-app/v4/test/util/testfactory"
+	blobtypes "github.com/celestiaorg/celestia-app/v4/x/blob/types"
 )
 
+const mebibyte = 1 << 20 // 1 MiB = 2^20 bytes = 1,048,576
+
 func BenchmarkGasPriceEstimation(b *testing.B) {
-	encfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	encfg := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	accounts := testfactory.GenerateAccounts(1)
 	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	infos := queryAccountInfo(testApp, accounts, kr)
-	signer, err := user.NewSigner(kr, encfg.TxConfig, testutil.ChainID, appconsts.LatestVersion, user.NewAccount(accounts[0], infos[0].AccountNum, infos[0].Sequence))
+	signer, err := user.NewSigner(kr, encfg.TxConfig, testutil.ChainID, user.NewAccount(accounts[0], infos[0].AccountNum, infos[0].Sequence))
 	require.NoError(b, err)
 
 	// 8 mb block
@@ -82,7 +85,7 @@ func BenchmarkGasPriceEstimation(b *testing.B) {
 }
 
 func generateRandomPFBs(b *testing.B, signer *user.Signer, account string, numberOfTransactions int, blobSize int) []types.Tx {
-	rand := tmrand.NewRand()
+	rand := random.New()
 	gasLimit := blobtypes.DefaultEstimateGas([]uint32{uint32(blobSize)})
 	blobs := blobfactory.ManyBlobs(rand, []share.Namespace{share.RandomBlobNamespace()}, []int{blobSize})
 	txs := make([]types.Tx, numberOfTransactions)


### PR DESCRIPTION
```
go test -tags=bench_gas_estimation -bench BenchmarkGasPriceEstimation ./app/benchmarks/...
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-app/v4/app/benchmarks
cpu: Apple M3 Pro
BenchmarkGasPriceEstimation/10kb_PFBs_filling_120%_of_a_block-12         	 7755766	       152.6 ns/op
BenchmarkGasPriceEstimation/100kb_PFBs_filling_120%_of_a_block-12        	 8136848	       142.9 ns/op
BenchmarkGasPriceEstimation/1mb_PFBs_filling_120%_of_a_block-12          	 8354092	       141.9 ns/op
BenchmarkGasPriceEstimation/2mb_PFBs_filling_120%_of_a_block-12          	 8355410	       141.0 ns/op
PASS
ok  	github.com/celestiaorg/celestia-app/v4/app/benchmarks	10.019s
```